### PR TITLE
Added GitVersion to automatically increment package and assembly version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Please first discuss the change you wish to make via an issue before making a change. 
+
+## Pull request process
+
+1. Ensure that there are automated tests that cover any changes 
+1. Update the README.md with details of any significant changes to functionality
+1. Ensure that your commit messages increment the version using [GitVersion syntax](https://gitversion.readthedocs.io/en/latest/input/docs/more-info/version-increments/). If no message is found then the patch version will be incremented by default.
+1. You may merge the pull request once it meets all of the required checks. If you do not have permision, a reviewer will do it for you

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+mode: mainline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,12 @@ stages:
     - job: BuildJob
       displayName: Build
       steps:
-        - task: GitVersion@5
+        - task: gitversion/setup@0
           inputs:
-            runtime: 'core'
+            versionSpec: '5.x'
+        - task: gitversion/execute@0
+          inputs:
+            useConfigFile: true
             updateAssemblyInfo: true
             updateAssemblyInfoFilename: 'bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
         - task: NuGetToolInstaller@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,14 @@ stages:
       displayName: Build
       steps:
         - task: gitversion/setup@0
+          displayName: Install GitVersion
           inputs:
             versionSpec: '5.x'
         - task: gitversion/execute@0
+          displayName: Execute GitVersion
           inputs:
             useConfigFile: true
+            configFilePath: 'GitVersion.yml'
             updateAssemblyInfo: true
             updateAssemblyInfoFilename: 'bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
         - task: NuGetToolInstaller@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,4 @@
+name: $(GITVERSION_FullSemVer)
 trigger:
  batch: true
  branches:
@@ -16,6 +17,11 @@ stages:
     - job: BuildJob
       displayName: Build
       steps:
+        - task: GitVersion@5
+          inputs:
+            runtime: 'core'
+            updateAssemblyInfo: true
+            updateAssemblyInfoFilename: 'bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
         - task: NuGetToolInstaller@1
           displayName: Install NuGet
         - task: NuGetCommand@2
@@ -38,9 +44,11 @@ stages:
           inputs:
             command: pack
             packagesToPack: bindings\src\Capgemini.PowerApps.SpecFlowBindings\Capgemini.PowerApps.SpecFlowBindings.csproj
-            includeReferencedProjects: true
+            includeReferencedProjects: false
             packDestination: '$(Build.ArtifactStagingDirectory)/out'
             configuration: $(buildConfiguration) 
+            versioningScheme: byEnvVar
+            versionEnvVar: 'GitVersion.NuGetVersionV2'
         - publish: $(Build.ArtifactStagingDirectory)/out
           displayName: Publish NuGet artifact
           artifact: Capgemini.PowerApps.SpecFlowBindings
@@ -50,8 +58,8 @@ stages:
         - publish: bindings\tests\Capgemini.PowerApps.SpecFlowBindings.UiTests\bin\$(buildConfiguration)
           displayName: Publish tests
           artifact: tests
-  - stage: UnitTest
-    displayName: Unit test
+  - stage: Test
+    displayName: Test
     dependsOn: Build
     jobs:
     - job: UnitTestJob
@@ -80,10 +88,6 @@ stages:
             codeCoverageTool: Cobertura
             summaryFileLocation: '$(Pipeline.Workspace)/driver/coverage/cobertura/cobertura.xml'
             reportDirectory: '$(Pipeline.Workspace)/driver/coverage/html'
-  - stage: UiTest
-    displayName: UI Test
-    dependsOn: Build
-    jobs:
     - job: UiTestJob
       displayName: UI Test
       variables:
@@ -108,11 +112,11 @@ stages:
             POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
             POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
             POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
-  - stage: PublishPackage
-    displayName: Publish Package
+  - stage: Publish
+    displayName: Publish
     jobs:
-      - job: PublishToNuGetGalleryJob
-        displayName: Publish To NuGet Gallery
+      - job: PublishJob
+        displayName: Publish 
         steps:
           - checkout: none
           - download: current

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,6 +109,7 @@ stages:
             uiTests: true
             runInParallel: true
             codeCoverageEnabled: true
+            runSettingsFile: $(Pipeline.Workspace)\tests\CodeCoverage.runsettings
             testAssemblyVer2: |
               **\*UiTests.dll
               !**\*TestAdapter.dll

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,9 @@ stages:
           displayName: Execute GitVersion
           inputs:
             useConfigFile: true
-            configFilePath: 'GitVersion.yml'
+            configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
             updateAssemblyInfo: true
-            updateAssemblyInfoFilename: 'bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
+            updateAssemblyInfoFilename: '$(Build.SourcesDirectory)\bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
         - task: NuGetToolInstaller@1
           displayName: Install NuGet
         - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,4 +128,4 @@ stages:
               command: push
               packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
               nuGetFeedType: external
-              publishFeedCredentials: NuGet
+              publishFeedCredentials: Capgemini_UK

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,7 @@ stages:
           inputs:
             uiTests: true
             runInParallel: true
+            codeCoverageEnabled: true
             testAssemblyVer2: |
               **\*UiTests.dll
               !**\*TestAdapter.dll

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,74 +58,74 @@ stages:
         - publish: bindings\tests\Capgemini.PowerApps.SpecFlowBindings.UiTests\bin\$(buildConfiguration)
           displayName: Publish tests
           artifact: tests
-  - stage: Test
-    displayName: Test
-    dependsOn: Build
-    jobs:
-    - job: UnitTestJob
-      displayName: Unit Test
-      steps:
-        - checkout: none
-        - download: current
-          displayName: Download driver
-          artifact: driver
-        - task: Npm@1
-          displayName: Run tests
-          continueOnError: true
-          inputs:
-            command: custom
-            verbose: false
-            customCommand: 'run test'
-            publishRegistry: useFeed
-            workingDir: $(Pipeline.Workspace)/driver
-        - task: PublishTestResults@2
-          displayName: Publish test results
-          inputs:
-            testResultsFiles: '$(Pipeline.Workspace)\driver\**\TESTS-*.xml'
-        - task: PublishCodeCoverageResults@1
-          displayName: Publish code coverage results
-          inputs:
-            codeCoverageTool: Cobertura
-            summaryFileLocation: '$(Pipeline.Workspace)/driver/coverage/cobertura/cobertura.xml'
-            reportDirectory: '$(Pipeline.Workspace)/driver/coverage/html'
-    - job: UiTestJob
-      displayName: UI Test
-      variables:
-        - group: Cap Dev - CI
-      steps:
-        - checkout: none
-        - download: current
-          displayName: Download tests
-          artifact: tests
-        - task: VSTest@2
-          displayName: Run tests
-          inputs:
-            uiTests: true
-            runInParallel: true
-            testAssemblyVer2: |
-              **\*UiTests.dll
-              !**\*TestAdapter.dll
-              !**\obj\**
-            searchFolder: $(Pipeline.Workspace)\tests
-          continueOnError: true
-          env:
-            POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
-            POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
-            POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
-  - stage: Publish
-    displayName: Publish
-    jobs:
-      - job: PublishJob
-        displayName: Publish 
-        steps:
-          - checkout: none
-          - download: current
-            displayName: Download NuGet package artifact
-            artifact: Capgemini.PowerApps.SpecFlowBindings
-          - task: NuGetCommand@2
-            displayName: 'NuGet push'
-            inputs:
-              command: push
-              packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
-              nuGetFeedType: external
-              publishFeedCredentials: Capgemini_UK
+  # - stage: Test
+  #   displayName: Test
+  #   dependsOn: Build
+  #   jobs:
+  #   - job: UnitTestJob
+  #     displayName: Unit Test
+  #     steps:
+  #       - checkout: none
+  #       - download: current
+  #         displayName: Download driver
+  #         artifact: driver
+  #       - task: Npm@1
+  #         displayName: Run tests
+  #         continueOnError: true
+  #         inputs:
+  #           command: custom
+  #           verbose: false
+  #           customCommand: 'run test'
+  #           publishRegistry: useFeed
+  #           workingDir: $(Pipeline.Workspace)/driver
+  #       - task: PublishTestResults@2
+  #         displayName: Publish test results
+  #         inputs:
+  #           testResultsFiles: '$(Pipeline.Workspace)\driver\**\TESTS-*.xml'
+  #       - task: PublishCodeCoverageResults@1
+  #         displayName: Publish code coverage results
+  #         inputs:
+  #           codeCoverageTool: Cobertura
+  #           summaryFileLocation: '$(Pipeline.Workspace)/driver/coverage/cobertura/cobertura.xml'
+  #           reportDirectory: '$(Pipeline.Workspace)/driver/coverage/html'
+  #   - job: UiTestJob
+  #     displayName: UI Test
+  #     variables:
+  #       - group: Cap Dev - CI
+  #     steps:
+  #       - checkout: none
+  #       - download: current
+  #         displayName: Download tests
+  #         artifact: tests
+  #       - task: VSTest@2
+  #         displayName: Run tests
+  #         inputs:
+  #           uiTests: true
+  #           runInParallel: true
+  #           testAssemblyVer2: |
+  #             **\*UiTests.dll
+  #             !**\*TestAdapter.dll
+  #             !**\obj\**
+  #           searchFolder: $(Pipeline.Workspace)\tests
+  #         continueOnError: true
+  #         env:
+  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
+  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
+  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
+  # - stage: Publish
+  #   displayName: Publish
+  #   jobs:
+  #     - job: PublishJob
+  #       displayName: Publish 
+  #       steps:
+  #         - checkout: none
+  #         - download: current
+  #           displayName: Download NuGet package artifact
+  #           artifact: Capgemini.PowerApps.SpecFlowBindings
+  #         - task: NuGetCommand@2
+  #           displayName: 'NuGet push'
+  #           inputs:
+  #             command: push
+  #             packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
+  #             nuGetFeedType: external
+  #             publishFeedCredentials: Capgemini_UK

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,74 +58,74 @@ stages:
         - publish: bindings\tests\Capgemini.PowerApps.SpecFlowBindings.UiTests\bin\$(buildConfiguration)
           displayName: Publish tests
           artifact: tests
-  # - stage: Test
-  #   displayName: Test
-  #   dependsOn: Build
-  #   jobs:
-  #   - job: UnitTestJob
-  #     displayName: Unit Test
-  #     steps:
-  #       - checkout: none
-  #       - download: current
-  #         displayName: Download driver
-  #         artifact: driver
-  #       - task: Npm@1
-  #         displayName: Run tests
-  #         continueOnError: true
-  #         inputs:
-  #           command: custom
-  #           verbose: false
-  #           customCommand: 'run test'
-  #           publishRegistry: useFeed
-  #           workingDir: $(Pipeline.Workspace)/driver
-  #       - task: PublishTestResults@2
-  #         displayName: Publish test results
-  #         inputs:
-  #           testResultsFiles: '$(Pipeline.Workspace)\driver\**\TESTS-*.xml'
-  #       - task: PublishCodeCoverageResults@1
-  #         displayName: Publish code coverage results
-  #         inputs:
-  #           codeCoverageTool: Cobertura
-  #           summaryFileLocation: '$(Pipeline.Workspace)/driver/coverage/cobertura/cobertura.xml'
-  #           reportDirectory: '$(Pipeline.Workspace)/driver/coverage/html'
-  #   - job: UiTestJob
-  #     displayName: UI Test
-  #     variables:
-  #       - group: Cap Dev - CI
-  #     steps:
-  #       - checkout: none
-  #       - download: current
-  #         displayName: Download tests
-  #         artifact: tests
-  #       - task: VSTest@2
-  #         displayName: Run tests
-  #         inputs:
-  #           uiTests: true
-  #           runInParallel: true
-  #           testAssemblyVer2: |
-  #             **\*UiTests.dll
-  #             !**\*TestAdapter.dll
-  #             !**\obj\**
-  #           searchFolder: $(Pipeline.Workspace)\tests
-  #         continueOnError: true
-  #         env:
-  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
-  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
-  #           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
-  # - stage: Publish
-  #   displayName: Publish
-  #   jobs:
-  #     - job: PublishJob
-  #       displayName: Publish 
-  #       steps:
-  #         - checkout: none
-  #         - download: current
-  #           displayName: Download NuGet package artifact
-  #           artifact: Capgemini.PowerApps.SpecFlowBindings
-  #         - task: NuGetCommand@2
-  #           displayName: 'NuGet push'
-  #           inputs:
-  #             command: push
-  #             packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
-  #             nuGetFeedType: external
-  #             publishFeedCredentials: Capgemini_UK
+  - stage: Test
+    displayName: Test
+    dependsOn: Build
+    jobs:
+    - job: UnitTestJob
+      displayName: Unit Test
+      steps:
+        - checkout: none
+        - download: current
+          displayName: Download driver
+          artifact: driver
+        - task: Npm@1
+          displayName: Run tests
+          continueOnError: true
+          inputs:
+            command: custom
+            verbose: false
+            customCommand: 'run test'
+            publishRegistry: useFeed
+            workingDir: $(Pipeline.Workspace)/driver
+        - task: PublishTestResults@2
+          displayName: Publish test results
+          inputs:
+            testResultsFiles: '$(Pipeline.Workspace)\driver\**\TESTS-*.xml'
+        - task: PublishCodeCoverageResults@1
+          displayName: Publish code coverage results
+          inputs:
+            codeCoverageTool: Cobertura
+            summaryFileLocation: '$(Pipeline.Workspace)/driver/coverage/cobertura/cobertura.xml'
+            reportDirectory: '$(Pipeline.Workspace)/driver/coverage/html'
+    - job: UiTestJob
+      displayName: UI Test
+      variables:
+        - group: Cap Dev - CI
+      steps:
+        - checkout: none
+        - download: current
+          displayName: Download tests
+          artifact: tests
+        - task: VSTest@2
+          displayName: Run tests
+          inputs:
+            uiTests: true
+            runInParallel: true
+            testAssemblyVer2: |
+              **\*UiTests.dll
+              !**\*TestAdapter.dll
+              !**\obj\**
+            searchFolder: $(Pipeline.Workspace)\tests
+          continueOnError: true
+          env:
+            POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
+            POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
+            POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
+  - stage: Publish
+    displayName: Publish
+    jobs:
+      - job: PublishJob
+        displayName: Publish 
+        steps:
+          - checkout: none
+          - download: current
+            displayName: Download NuGet package artifact
+            artifact: Capgemini.PowerApps.SpecFlowBindings
+          - task: NuGetCommand@2
+            displayName: 'NuGet push'
+            inputs:
+              command: push
+              packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: Capgemini_UK

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.nuspec
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.nuspec
@@ -4,7 +4,7 @@
     <id>Capgemini.PowerApps.SpecFlowBindings</id>
     <title>Power Apps SpecFlow Bindings</title>
     <icon>images\icon.png</icon>
-    <version>0.7.1-alpha</version>
+    <version>0.1.0</version>
     <description>A SpecFlow bindings library for Power Apps.</description>
     <authors>Capgemini_UK, ewingjm</authors>
     <owners>Capgemini_UK, ewingjm</owners>

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/CodeCoverage.runsettings
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/CodeCoverage.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <!-- Configurations for data collectors -->
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+                <Configuration>
+                    <CodeCoverage>
+                        <ModulePaths>
+                            <Include>
+                                <ModulePath>Capgemini.PowerApps.SpecFlowBindings.dll</ModulePath>
+                            </Include>
+                        </ModulePaths>
+                    </CodeCoverage>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
***NO_CI*** the resulting commit of this PR needs to be tagged with the initial version before the CI pipeline can run

GitVersion has been configured in mainline mode. This means that it will automatically increment to a full version on each commit in master. 

Using default version bump regex:

```yaml
major-version-bump-message: '\+semver:\s?(breaking|major)'
minor-version-bump-message: '\+semver:\s?(feature|minor)'
patch-version-bump-message: '\+semver:\s?(fix|patch)'
```

Patch version incremented by default. For more info: https://gitversion.net/docs/more-info/version-increments

Pipeline has also been updated to pack the NuGet package using the version from GitVersion.

**Note: we will need to stop using pre-release tags as mainline mode on GitVersion doesn't support it. I believe this is fine as, in SemVer, anything before the first major version is pre-release by definition**
 


