### PR TITLE
Fixed issue with UI tests not running with code coverage in pipeline

### DIFF
--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Capgemini.PowerApps.SpecFlowBindings.UiTests.csproj
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Capgemini.PowerApps.SpecFlowBindings.UiTests.csproj
@@ -140,6 +140,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="CodeCoverage.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="DataSteps.feature" />
     <None Include="Data\an account with aliased contact.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/CodeCoverage.runsettings
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/CodeCoverage.runsettings
@@ -8,7 +8,7 @@
                     <CodeCoverage>
                         <ModulePaths>
                             <Include>
-                                <ModulePath>Capgemini.PowerApps.SpecFlowBindings.dll</ModulePath>
+                                <ModulePath>.*\.SpecFlowBindings.dll</ModulePath>
                             </Include>
                         </ModulePaths>
                     </CodeCoverage>


### PR DESCRIPTION
## Purpose
The UI tests were failing to run due to not being able to find the .runsettings file that was configured. 

## Approach

Updated the UI test project to copy the .runsettings file to the output directory (and thus get published in the test artifact, accessible to the test job)

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
