### PR TITLE
ci: added whitesource bolt to build stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,10 @@ stages:
         - publish: bindings\tests\Capgemini.PowerApps.SpecFlowBindings.UiTests\bin\$(buildConfiguration)
           displayName: Publish tests
           artifact: tests
+        - task: WhiteSource Bolt@20
+          displayName: Detect security and licence issues
+          inputs:
+            cwd: '$(Build.SourcesDirectory)'
   - stage: Test
     displayName: Test
     dependsOn: Build


### PR DESCRIPTION
## Purpose
WhiteSource Bolt can be used to detect security or licensing issues.

## Approach
Integrated WhiteSource Bolt into the CI pipeline.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
