### PR TITLE
[ci] updated pipeline to automatically create GitHub release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,3 +145,21 @@ stages:
               packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
               nuGetFeedType: external
               publishFeedCredentials: Capgemini_UK
+          - task: GitHubRelease@1
+            displayName: Create GitHub releaes
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+            inputs:
+              gitHubConnection: 'Github Capgemini'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: 'v$(GitVersion.SemVer)'
+              assets: '$(Build.ArtifactStagingDirectory)/out/*'
+              changeLogCompareToRelease: 'lastFullRelease'
+              changeLogType: 'issueBased'
+              changeLogLabels: |
+                [
+                { "label" : "bug", "displayName" : "Bugs", "state" : "closed" },
+                { "label" : "enhancement", "displayName" : "Impovements", "state" : "closed" }
+                ]


### PR DESCRIPTION
## Purpose
GitHub releases are a useful way of tagging releases in the commit history and tracking bugs and issues closed in each release.

## Approach
The CI pipeline will now automatically create a GitHub release on when: 

- it has successfully deployed to NuGet.org 
- the pipeline is running on the master branch

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
