### PR TITLE
fix: error messages not returned when test data setup fails

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -183,7 +183,7 @@
     <Compile Include="Steps\RelatedGridSteps.cs" />
     <Compile Include="Steps\TimelineSteps.cs" />
     <Compile Include="Steps\UtilitySteps.cs" />
-    <Compile Include="TestDataRepository.cs" />
+    <Compile Include="FileDataRepository.cs" />
     <Compile Include="TestDriver.cs" />
     <Compile Include="Transformations\EasyReproTransformations.cs" />
   </ItemGroup>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/FileDataRepository.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/FileDataRepository.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Reads test data from JSON files.
     /// </summary>
-    public class TestDataRepository : ITestDataRepository
+    public class FileDataRepository : ITestDataRepository
     {
         private const string FileDirectory = "data";
         private static readonly string RootDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -62,7 +62,7 @@
         /// <summary>
         /// Gets a repository provides access to test data.
         /// </summary>
-        protected static ITestDataRepository TestDataRepository => testDataRepository ?? (testDataRepository = new TestDataRepository());
+        protected static ITestDataRepository TestDataRepository => testDataRepository ?? (testDataRepository = new FileDataRepository());
 
         /// <summary>
         /// Gets the EasyRepro WebClient.

--- a/driver/src/TestDriver.ts
+++ b/driver/src/TestDriver.ts
@@ -1,5 +1,4 @@
 /// <reference path="./data/DataManager.ts"/>
-/// <reference path="./TestEvents.ts"/>
 
 namespace Capgemini.Dynamics.Testing {
     /**
@@ -28,7 +27,6 @@ namespace Capgemini.Dynamics.Testing {
                 );
             }
             this.dataManager = dataManager;
-            this.registerListeners();
         }
 
         /**
@@ -42,6 +40,7 @@ namespace Capgemini.Dynamics.Testing {
         public async loadTestData(json: string): Promise<Xrm.LookupValue> {
             const testRecord = JSON.parse(json) as Data.ITestRecord;
             const logicalName = testRecord["@logicalName"];
+
             return this.dataManager.createData(logicalName, testRecord);
         }
 
@@ -78,28 +77,6 @@ namespace Capgemini.Dynamics.Testing {
          */
         public getRecordReference(alias: string): Xrm.LookupValue {
             return this.dataManager.createdRecordsByAlias[alias];
-        }
-
-        private registerListeners(): void {
-            top.addEventListener(TestEvents.LoadTestDataRequested, (e) => this.routeToListener(e, this.loadTestData.bind(this)));
-            top.addEventListener(TestEvents.DeleteTestDataRequested, (e) => this.routeToListener(e, this.deleteTestData.bind(this)));
-            top.addEventListener(TestEvents.OpenRecordRequested, (e) => this.routeToListener(e, this.openTestRecord.bind(this)));
-            top.addEventListener(TestEvents.GetRecordReferenceRequested, (e) => this.routeToListener(e, this.getRecordReference.bind(this)));
-        }
-
-        private routeToListener(e: Event, listener: (...args: any[]) => any) {
-            const detail = (e as CustomEvent).detail;
-            const result = detail ? listener(detail.data) : listener();
-
-            if (!detail || !detail.callback) {
-                return;
-            }
-            if (result && result.then) {
-                result.then(detail.callback);
-            }
-            else if (result) {
-                detail.callback(result);
-            }
         }
     }
 }

--- a/driver/src/TestEvents.ts
+++ b/driver/src/TestEvents.ts
@@ -1,8 +1,0 @@
-namespace Capgemini.Dynamics.Testing {
-    export enum TestEvents {
-        LoadTestDataRequested = "driver.loadTestDataRequested",
-        DeleteTestDataRequested = "driver.deleteTestDataRequested",
-        OpenRecordRequested = "driver.openRecordRequested",
-        GetRecordReferenceRequested = "driver.getRecordReferenceRequested"
-    }
-}

--- a/driver/src/tests/TestDriver.spec.ts
+++ b/driver/src/tests/TestDriver.spec.ts
@@ -9,45 +9,6 @@ namespace Capgemini.Dynamics.Testing.Tests {
             dataManager = jasmine.createSpyObj<Data.DataManager>("DataManager", ["createData", "cleanup", "createdRecords", "createdRecordsByAlias"]);
             testDriver = new TestDriver(dataManager);
         });
-        it("listens for the specXrm.loadTestDataRequested event", () => {
-            const data = JSON.stringify({
-                name: "Sample Account",
-            });
-            const event = new CustomEvent(
-                TestEvents.LoadTestDataRequested,
-                {
-                    detail: {
-                        data,
-                    },
-                });
-            const createDataCalls = dataManager.createData.calls.count();
-
-            window.top.dispatchEvent(event);
-
-            expect(dataManager.createData).toHaveBeenCalledTimes(createDataCalls + 1);
-        });
-        it("listens for the specXrm.deleteTestDataRequested event", () => {
-            const event = new CustomEvent(TestEvents.DeleteTestDataRequested);
-            const cleanupCalls = dataManager.cleanup.calls.count();
-
-            window.top.dispatchEvent(event);
-
-            expect(dataManager.cleanup).toHaveBeenCalledTimes(cleanupCalls + 1);
-        });
-        it("listens for the specXrm.openRecordRequested event", async () => {
-            const openForm = jasmine.createSpy("openForm");
-            window.Xrm = {
-                Navigation: {
-                    openForm,
-                },
-            } as any;
-            dataManager.createdRecordsByAlias.someAlias = { id: "<account-id>", entityType: "account" };
-
-            const event = new CustomEvent(TestEvents.OpenRecordRequested, { detail: { data: "someAlias" } });
-            window.top.dispatchEvent(event);
-
-            expect(openForm.calls.first().args[0].entityId).toBe("<account-id>");
-        });
         describe(".loadJsonData(json)", () => {
             it("uses the TestDataManager to create the test data", () => {
                 const logicalName = "account";


### PR DESCRIPTION
## Purpose
Unhandled exceptions encountered by the driver when using the `Given I have created` step binding (or any binding that makes asynchronous calls to the driver) would result in a timeout exception rather than a meaningful exception that could be used to fix the problem. Fixes #8.

## Approach
A slight refactor addresses this problem by returning a string to the callback with a prefix that identifies it as an exception. This is because `IJavaScriptExecutor.executeAsyncScript()` doesn't return JavaScript `Error`s as their own identifiable type.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
