### PR TITLE
fix: switch lookup view throws null reference

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -69,7 +69,7 @@
             // XrmApp.Lookup.SwitchView(viewName);
             Driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Lookup.ChangeViewButton])).Click(true);
             Driver.WaitUntilAvailable(By.XPath("//li[contains(@role,'treeitem') and contains(@class,'bu')]"));
-            Driver.WaitUntilAvailable(By.CssSelector("li[a ria-label='" + viewName + "']")).Click();
+            Driver.WaitUntilAvailable(By.CssSelector($"li[aria-label='{viewName}']")).Click();
             Driver.WaitForTransaction();
         }
 


### PR DESCRIPTION
## Purpose
`When I select the '(.*)' view in the lookup` step was throwing a null reference exception.

## Approach
Corrects an issue with a CSS selector.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful

Fixes #30