### PR TITLE
ci: fixed failing automatic release creation 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  GitVersion.SemVer: ''
 stages:
   - stage: Build
     jobs:
@@ -155,11 +156,8 @@ stages:
               target: '$(Build.SourceVersion)'
               tagSource: 'userSpecifiedTag'
               tag: 'v$(GitVersion.SemVer)'
-              assets: '$(Build.ArtifactStagingDirectory)/out/*'
+              releaseNotesSource: 'inline'
+              assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
+              isPreRelease: true
               changeLogCompareToRelease: 'lastFullRelease'
-              changeLogType: 'issueBased'
-              changeLogLabels: |
-                [
-                { "label" : "bug", "displayName" : "Bugs", "state" : "closed" },
-                { "label" : "enhancement", "displayName" : "Impovements", "state" : "closed" }
-                ]
+              changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   GitVersion.SemVer: ''
+  GitVersion.PreReleaseTag: ''
 stages:
   - stage: Build
     jobs:
@@ -161,4 +162,5 @@ stages:
               assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
               isPreRelease: true
               changeLogCompareToRelease: 'lastFullRelease'
-              changeLogType: 'commitBased'
+              changeLogType: 'issueBased'
+              changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugs", "state" : "closed" }, { "label" : "enhancement", "displayName" : "Improvements", "state" : "closed" }]'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,7 @@ stages:
           displayName: Publish tests
           artifact: tests
         - task: WhiteSource Bolt@20
+          condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
           displayName: Detect security and licence issues
           inputs:
             cwd: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ stages:
             configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
             updateAssemblyInfo: true
             updateAssemblyInfoFilename: '$(Build.SourcesDirectory)\bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
-        - bash: 'echo $(GitVersion.SemVer)' 
         - task: NuGetToolInstaller@1
           displayName: Install NuGet
         - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ stages:
             configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
             updateAssemblyInfo: true
             updateAssemblyInfoFilename: '$(Build.SourcesDirectory)\bindings\src\Capgemini.PowerApps.SpecFlowBindings\Properties\AssemblyInfo.cs'
+        - bash: 'echo $(GitVersion.SemVer)' 
         - task: NuGetToolInstaller@1
           displayName: Install NuGet
         - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   GitVersion.SemVer: ''
-  GitVersion.PreReleaseTag: ''
 stages:
   - stage: Build
     jobs:


### PR DESCRIPTION
## Purpose
Automatic release creation was:

- missing assets due to pointing to the wrong folder. 
- using an incorrect version number due to a missing pipeline variable
- not creating pre-release versions

## Approach

Fixed the issues above in the pipeline.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
