### PR TITLE
ci: fix version number set in automatic release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,13 @@ stages:
             name: SetGitVersionTask
   - stage: TestGitVersionVariableAccessStage
     displayName: Temporary stage to test variable access
+    variables: 
+          GitVersion.SemVer: $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
     jobs:
       - job: TestGitVersionVariableAccessJob
         displayName: Temporary job to test variable access
         steps: 
           - task: CmdLine@2
-            variables: 
-              GitVersion.SemVer: $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
             inputs:
               script: echo $(GitVersion.SemVer)
   - stage: Publish

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,9 @@ stages:
     jobs:
       - job: TestGitVersionVariableAccessJob
         variables: 
-          GitVersion.SemVer: $[stageDependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
+          SemVer: $[ stageDependencies.TestGitVersionStage.TestGitVersionJob.outputs['GitVersionSemVer'] ]
         displayName: Temporary job to test variable access
         steps: 
           - task: CmdLine@2
             inputs:
-              script: echo $(GitVersion.SemVer)
+              script: echo $(SemVer)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,9 +45,9 @@ stages:
               action: 'create'
               target: '$(Build.SourceVersion)'
               tagSource: 'userSpecifiedTag'
-              tag: 'v$(GitVersion.SemVer)'
+              tag: 'v$(SemVer)'
               releaseNotesSource: 'inline'
               assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
               isPreRelease: true
-              changeLogCompareToRelease: 'lastFullRelease'
+              changeLogCompareToRelease: 'lastNonDraftRelease'
               changeLogType: commitBased

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,14 +38,14 @@ stages:
             displayName: Create GitHub releaes
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
-              gitHubConnection: 'Github Capgemini'
+              gitHubConnection: 'GitHub (ewingjm)'
               repositoryName: '$(Build.Repository.Name)'
               action: 'create'
               target: '$(Build.SourceVersion)'
               tagSource: 'userSpecifiedTag'
-              tag: 'v$(GitVersion.SemVer)'
+              tag: 'v$(GITVERSION_FullSemVer)'
               releaseNotesSource: 'inline'
               assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
               isPreRelease: true
-              changeLogCompareToRelease: 'lastFullRelease'
+              changeLogCompareToRelease: lastNonDraftRelease
               changeLogType: commitBased

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,30 @@ stages:
     displayName: Build and test
     jobs:
     - template: templates/include-build-and-test-steps.yml
+  - stage: TestGitVersionStage
+    displayName: Temporary stage to test variable access
+    jobs:
+      - job: TestGitVersionJob
+        displayName: Temporary job to test variable access
+        steps: 
+          - task: gitversion/setup@0
+            displayName: Install GitVersion
+            inputs:
+              versionSpec: '5.x'
+          - task: gitversion/execute@0
+            displayName: Execute GitVersion
+            inputs:
+              useConfigFile: true
+              configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
+  - stage: TestGitVersionVariableAccessStage
+    displayName: Temporary stage to test variable access
+    jobs:
+      - job: TestGitVersionVariableAccessJob
+        displayName: Temporary job to test variable access
+        steps: 
+          - task: CmdLine@2
+            inputs:
+              script: 'echo $(GitVersion.SemVer)'
   - stage: Publish
     displayName: Publish
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,10 @@ stages:
         displayName: Temporary job to test variable access
         steps: 
           - task: CmdLine@2
+            variables: 
+              GitVersion.SemVer: $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
             inputs:
-              script: echo $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']
+              script: echo $(GitVersion.SemVer)
   - stage: Publish
     displayName: Publish
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
     jobs:
       - job: TestGitVersionVariableAccessJob
         variables: 
-          SemVer: $[ stageDependencies.TestGitVersionStage.TestGitVersionJob.outputs['GitVersionSemVer'] ]
+          SemVer: $[ stageDependencies.TestGitVersionStage.TestGitVersionJob.outputs['SetGitVersionTask.GitVersionSemVer'] ]
         displayName: Temporary job to test variable access
         steps: 
           - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,6 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 stages:
-  - stage: BuildAndTest
-    displayName: Build and test
-    jobs:
-    - template: templates/include-build-and-test-steps.yml
   - stage: TestGitVersionStage
     displayName: Temporary stage to test variable access
     jobs:
@@ -33,48 +29,17 @@ stages:
             inputs:
               useConfigFile: true
               configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
+          - pwsh: Write-Host "Setting output variable as $(GitVersion.SemVer)"
           - pwsh: Write-Host "##vso[task.setvariable variable=GitVersionSemVer;isOutput=true]$(GitVersion.SemVer)"
             name: SetGitVersionTask
   - stage: TestGitVersionVariableAccessStage
     displayName: Temporary stage to test variable access
-    variables: 
-          GitVersion.SemVer: $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
     jobs:
       - job: TestGitVersionVariableAccessJob
+        variables: 
+          GitVersion.SemVer: $[stageDependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']]
         displayName: Temporary job to test variable access
         steps: 
           - task: CmdLine@2
             inputs:
               script: echo $(GitVersion.SemVer)
-  - stage: Publish
-    displayName: Publish
-    jobs:
-      - job: PublishJob
-        displayName: Publish 
-        steps:
-          - checkout: none
-          - download: current
-            displayName: Download NuGet package artifact
-            artifact: Capgemini.PowerApps.SpecFlowBindings
-          - task: NuGetCommand@2
-            displayName: Push to NuGet.org
-            inputs:
-              command: push
-              packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
-              nuGetFeedType: external
-              publishFeedCredentials: Capgemini_UK
-          - task: GitHubRelease@1
-            displayName: Create GitHub releaes
-            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-            inputs:
-              gitHubConnection: 'GitHub (ewingjm)'
-              repositoryName: '$(Build.Repository.Name)'
-              action: 'create'
-              target: '$(Build.SourceVersion)'
-              tagSource: 'userSpecifiedTag'
-              tag: 'v$(GITVERSION_FullSemVer)'
-              releaseNotesSource: 'inline'
-              assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
-              isPreRelease: true
-              changeLogCompareToRelease: lastNonDraftRelease
-              changeLogType: commitBased

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,6 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  GitVersion.SemVer: ''
 stages:
   - stage: BuildAndTest
     displayName: Build and test
@@ -22,6 +21,8 @@ stages:
     jobs:
       - job: TestGitVersionJob
         displayName: Temporary job to test variable access
+        variables:
+          GitVersion.SemVer: ''
         steps: 
           - task: gitversion/setup@0
             displayName: Install GitVersion
@@ -32,6 +33,8 @@ stages:
             inputs:
               useConfigFile: true
               configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
+          - pwsh: Write-Host "##vso[task.setvariable variable=GitVersionSemVer;isOutput=true]$(GitVersion.SemVer)"
+            name: SetGitVersionTask
   - stage: TestGitVersionVariableAccessStage
     displayName: Temporary stage to test variable access
     jobs:
@@ -40,7 +43,7 @@ stages:
         steps: 
           - task: CmdLine@2
             inputs:
-              script: 'echo $(GITVERSION_FullSemVer)'
+              script: echo $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersion.GitVersionSemVer']
   - stage: Publish
     displayName: Publish
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
         steps: 
           - task: CmdLine@2
             inputs:
-              script: echo $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersion.GitVersionSemVer']
+              script: echo $[dependencies.TestGitVersionStage.outputs['TestGitVersionJob.SetGitVersionTask.GitVersionSemVer']
   - stage: Publish
     displayName: Publish
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
         steps: 
           - task: CmdLine@2
             inputs:
-              script: 'echo $(GitVersion.SemVer)'
+              script: 'echo $(GITVERSION_FullSemVer)'
   - stage: Publish
     displayName: Publish
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,35 +11,43 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  GitVersion.SemVer: ''
 stages:
-  - stage: TestGitVersionStage
-    displayName: Temporary stage to test variable access
+  - stage: BuildAndTest
+    displayName: Build and test
     jobs:
-      - job: TestGitVersionJob
-        displayName: Temporary job to test variable access
-        variables:
-          GitVersion.SemVer: ''
-        steps: 
-          - task: gitversion/setup@0
-            displayName: Install GitVersion
-            inputs:
-              versionSpec: '5.x'
-          - task: gitversion/execute@0
-            displayName: Execute GitVersion
-            inputs:
-              useConfigFile: true
-              configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
-          - pwsh: Write-Host "Setting output variable as $(GitVersion.SemVer)"
-          - pwsh: Write-Host "##vso[task.setvariable variable=GitVersionSemVer;isOutput=true]$(GitVersion.SemVer)"
-            name: SetGitVersionTask
-  - stage: TestGitVersionVariableAccessStage
-    displayName: Temporary stage to test variable access
+    - template: templates/include-build-and-test-steps.yml
+  - stage: Publish
+    displayName: Publish
     jobs:
-      - job: TestGitVersionVariableAccessJob
+      - job: PublishJob
+        displayName: Publish 
         variables: 
-          SemVer: $[ stageDependencies.TestGitVersionStage.TestGitVersionJob.outputs['SetGitVersionTask.GitVersionSemVer'] ]
-        displayName: Temporary job to test variable access
-        steps: 
-          - task: CmdLine@2
+          SemVer: $[ stageDependencies.BuildAndTest.BuildJob.outputs['OutputSemVerTask.SemVer'] ]
+        steps:
+          - checkout: none
+          - download: current
+            displayName: Download NuGet package artifact
+            artifact: Capgemini.PowerApps.SpecFlowBindings
+          - task: NuGetCommand@2
+            displayName: Push to NuGet.org
             inputs:
-              script: echo $(SemVer)
+              command: push
+              packagesToPush: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: Capgemini_UK
+          - task: GitHubRelease@1
+            displayName: Create GitHub releaes
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+            inputs:
+              gitHubConnection: 'Github Capgemini'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: 'v$(GitVersion.SemVer)'
+              releaseNotesSource: 'inline'
+              assets: '$(Pipeline.Workspace)/Capgemini.PowerApps.SpecFlowBindings/*'
+              isPreRelease: true
+              changeLogCompareToRelease: 'lastFullRelease'
+              changeLogType: commitBased

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -23,6 +23,8 @@ jobs:
           useConfigFile: true
           configFilePath: '$(Build.SourcesDirectory)\GitVersion.yml'
           updateAssemblyInfo: false
+      - pwsh: Write-Host "##vso[task.setvariable variable=SemVer;isOutput=true]$(GitVersion.SemVer)"
+        name: OutputSemVerTask
       - task: NuGetToolInstaller@1
         displayName: Install NuGet
       - task: NuGetCommand@2


### PR DESCRIPTION
## Purpose
The version number was not being set correctly in the deployment stage of the release. This is because the GitVersion pipeline variable was not set by the GitVersion task. Output variables are required to use variables across stages.

## Approach
Adds a task after the GitVersion task to set an output variable with the SemVer value. This can then be referenced in the deployment stage.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
