### PR TITLE
ci: fixed eslint integration with sonarcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Power Apps SpecFlow Bindings
 
-[![Build Status](https://capgeminiuk.visualstudio.com/GitHub%20Support/_apis/build/status/CI-Builds/NuGet%20Packages/Capgemini.PowerApps.SpecFlowBindings?branchName=master)](https://capgeminiuk.visualstudio.com/GitHub%20Support/_build/latest?definitionId=195&branchName=master)
+[![Build Status](https://capgeminiuk.visualstudio.com/GitHub%20Support/_apis/build/status/CI-Builds/NuGet%20Packages/Capgemini.PowerApps.SpecFlowBindings?branchName=master)](https://capgeminiuk.visualstudio.com/GitHub%20Support/_build/latest?definitionId=195&branchName=master) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Capgemini_powerapps-specflow-bindings&metric=alert_status)](https://sonarcloud.io/dashboard?id=Capgemini_powerapps-specflow-bindings) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Capgemini_powerapps-specflow-bindings&metric=coverage)](https://sonarcloud.io/dashboard?id=Capgemini_powerapps-specflow-bindings)
 
 A SpecFlow bindings library for Power Apps.
 

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -48,7 +48,7 @@ jobs:
           extraProperties: |
             sonar.javascript.lcov.reportPaths=driver/test_results/coverage/lcov/lcov.info
             sonar.coverage.exclusions=**\*spec.ts
-            sonar.eslint.reportPaths=driver/test_results/analysis/eslint.json
+            sonar.eslint.reportPaths=$(Build.SourcesDirectory)/driver/test_results/analysis/eslint.json
       - task: VSBuild@1
         displayName: Build solution
         inputs:


### PR DESCRIPTION
## Purpose
The ESLint report paths property was not able to find the report using a relative path.

## Approach
Updated to pipeline to use an absolute path.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
