### PR TITLE
fix: build targets unable to find driver.js

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/build/Capgemini.PowerApps.SpecFlowBindings.targets
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/build/Capgemini.PowerApps.SpecFlowBindings.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)specflow.driver.js">
-      <Link>specflow.driver.js</Link>
+    <None Include="$(MSBuildThisFileDirectory)driver.js">
+      <Link>driver.js</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>


### PR DESCRIPTION
## Purpose
Unable to build a consuming project due to the build being unable to find specflow.driver.js

## Approach
This file was renamed in #32 but the build targets were not updated to use the new file name.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
