### PR TITLE
fix: error that occurred for steps that rely on alias references

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
             displayName: Create GitHub releaes
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
-              gitHubConnection: 'Github Capgemini'
+              gitHubConnection: 'GitHub (ewingjm)'
               repositoryName: '$(Build.Repository.Name)'
               action: 'create'
               target: '$(Build.SourceVersion)'

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -56,7 +56,7 @@
         /// <inheritdoc/>
         public EntityReference GetTestRecordReference(string recordAlias)
         {
-            var obj = (Dictionary<string, object>)this.javascriptExecutor.ExecuteAsyncScript($"{TestDriverReference}.getRecordReference('{recordAlias}').then(arguments[arguments.length - 1]);");
+            var obj = (Dictionary<string, object>)this.javascriptExecutor.ExecuteScript($"{TestDriverReference}.getRecordReference('{recordAlias}');");
 
             return new EntityReference((string)obj["entityType"], Guid.Parse((string)obj["id"]));
         }


### PR DESCRIPTION
## Purpose
Some step bindings that rely on the `GetTestRecordReference()` method were failing.

## Approach
Makes the call to the driver synchronous rather than asynchronous.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
