### PR TITLE
New Lookup Binding with a test to cover it

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -135,6 +135,7 @@
         public static void WhenISelectARelatedLookupInTheForm(string lookupName)
         {
             Driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldExistingValue].Replace("[NAME]", lookupName))).Click();
+            Driver.WaitForTransaction();
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -126,5 +126,15 @@
                 recordNames.Rows.Should().Contain(r => r[0] == item, because: "every given records should be present in the flyout");
             }
         }
+
+        /// <summary>
+        /// Opens the related record by clicking on the link.
+        /// </summary>
+        /// <param name="lookupName">The name of the lookup.</param>
+        [When(@"I select a related '(.*)' lookup field")]
+        public static void WhenISelectARelatedLookupInTheForm(string lookupName)
+        {
+            Driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldExistingValue].Replace("[NAME]", lookupName))).Click();
+        }
     }
 }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
@@ -10,3 +10,10 @@ Scenario: User switches lookup views
 	And I select 'primarycontactid' lookup
 	#KNOWN BUG (TestCategory - Bug - Fail) https://github.com/microsoft/EasyRepro/blob/aadad319f713e169ce080524f533f20d86b23c97/Microsoft.Dynamics365.UIAutomation.Sample/UCI/Read/OpenContact.cs
 	And I select the 'All Contacts' view in the lookup
+
+Scenario: User selects a related record
+	Given I am logged in to the 'Sales Team Member' app as 'an admin'	
+	And I have created 'an aliased contact'
+	And I have created 'an account with aliased contact'
+	And I have opened 'a sample account'
+	When I select a related 'primarycontactid' lookup field


### PR DESCRIPTION
## Purpose
Adds the ability to click a related lookup field on the form.

## Approach
New behaviour that is missing from easyrepro. Uses existing elements and extends it.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
