### PR TITLE
fix: faker error for nested lookups in test data

### DIFF
--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Data/data decorated with faker moustache syntax.json
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Data/data decorated with faker moustache syntax.json
@@ -5,5 +5,9 @@
   "firstname": "{{name.lastName}}",
   "creditlimit@faker.number": "{{finance.amount}}",
   "emailaddress1": "{{internet.email}}",
-  "birthdate@faker.date":  "{{date.past(90)}}"
+  "birthdate@faker.date": "{{date.past(90)}}",
+  "owningteam": {
+    "@alias": "a nested faked record",
+    "name": "{{name.jobArea}}"
+  }
 }

--- a/driver/src/data/fakerPreprocessor.ts
+++ b/driver/src/data/fakerPreprocessor.ts
@@ -8,11 +8,29 @@ export default class FakerPreprocessor extends Preprocessor {
     return FakerPreprocessor.parse(FakerPreprocessor.fake(data));
   }
 
-  private static fake(data: Record) : string {
-    return faker.fake(JSON.stringify(data));
+  private static fake(data: Record): string {
+    const fakedData = data;
+
+    Object.keys(data).forEach((key) => {
+      const value = fakedData[key];
+
+      if (value === null) {
+        return;
+      }
+
+      if (Array.isArray(value) && value !== null) {
+        fakedData[key] = value.map((arrayItem) => JSON.parse(this.fake(arrayItem as Record)));
+      } else if (typeof value === 'object' && value !== null) {
+        fakedData[key] = JSON.parse(this.fake(value as Record));
+      } else if (typeof value === 'string') {
+        fakedData[key] = faker.fake(value);
+      }
+    });
+
+    return JSON.stringify(fakedData);
   }
 
-  private static parse(data: string) : Record {
+  private static parse(data: string): Record {
     const cleansedData = JSON.parse(data);
 
     Object.keys(cleansedData).forEach((property) => {

--- a/driver/test/data/fakerPreprocessor.spec.ts
+++ b/driver/test/data/fakerPreprocessor.spec.ts
@@ -13,18 +13,18 @@ describe('FakerPreprocessor', () => {
   describe('.preprocess(data)', () => {
     it('calls faker.fake on data', async () => {
       const data = { foo: 'bar' };
-      fakeSpy.and.returnValue('{ "foo": "baz" }');
+      fakeSpy.and.returnValue('baz');
 
       fakerPreprocessor.preprocess(data);
 
-      expect(fakeSpy).toHaveBeenCalledWith(JSON.stringify(data));
+      expect(fakeSpy).toHaveBeenCalledWith('bar');
     });
 
     it('replaces @faker.number properties with number equivalent', () => {
       const data = {
         'foo@faker.number': '{{random.number}}',
       };
-      fakeSpy.and.returnValue('{ "foo@faker.number": "10.50" }');
+      fakeSpy.and.returnValue('10.50');
 
       const result = fakerPreprocessor.preprocess(data);
 
@@ -36,7 +36,7 @@ describe('FakerPreprocessor', () => {
       const data = {
         'foo@faker.number': '{{random.word}}',
       };
-      fakeSpy.and.returnValue('{ "foo@faker.number": "baz" }');
+      fakeSpy.and.returnValue('baz');
 
       expect(() => fakerPreprocessor.preprocess(data)).toThrowError();
     });
@@ -46,7 +46,7 @@ describe('FakerPreprocessor', () => {
         'foo@faker.date': '{{date.recent}}',
       };
       const date = new Date();
-      fakeSpy.and.returnValue(`{ "foo@faker.date": "${date}" }`);
+      fakeSpy.and.returnValue(`${date}`);
 
       const result = fakerPreprocessor.preprocess(data);
 
@@ -59,7 +59,7 @@ describe('FakerPreprocessor', () => {
         'foo@faker.datetime': '{{date.recent}}',
       };
       const date = new Date();
-      fakeSpy.and.returnValue(`{ "foo@faker.datetime": "${date}" }`);
+      fakeSpy.and.returnValue(`${date}`);
 
       const result = fakerPreprocessor.preprocess(data);
 
@@ -72,7 +72,7 @@ describe('FakerPreprocessor', () => {
         'foo@faker.date': 'this isn\'t a valid date',
         'bar@faker.datetime': 'this isn\'t a valid datetime',
       };
-      fakeSpy.and.returnValue('{ "foo@faker.date": "this isn\'t a valid date", "bar@faker.datetime": "this isn\'t a valid datetime" }');
+      fakeSpy.and.returnValues('this isn\'t a valid date', 'this isn\'t a valid datetime');
 
       expect(() => fakerPreprocessor.preprocess(data)).toThrowError();
     });
@@ -81,7 +81,7 @@ describe('FakerPreprocessor', () => {
       const data = {
         lookup: { 'foo@faker.number': '{{random.number}}' },
       };
-      fakeSpy.and.returnValue('{ "lookup": { "foo@faker.number": "10.50" } }');
+      fakeSpy.and.returnValue('10.50');
 
       const result = fakerPreprocessor.preprocess(data);
       const lookup = result.lookup as any;
@@ -94,7 +94,7 @@ describe('FakerPreprocessor', () => {
       const data = {
         relationship: [{ 'foo@faker.number': '{{random.number}}' }],
       };
-      fakeSpy.and.returnValue('{ "relationship": [ { "foo@faker.number": "10.50" } ] }');
+      fakeSpy.and.returnValue('10.50');
 
       const result = fakerPreprocessor.preprocess(data);
       const relatedRecord = (result.relationship as any[])[0];


### PR DESCRIPTION
## Purpose
JSON syntax was mistakenly being interpreted as faker syntax. A nested lookup at the bottom of the JSON would end with `}}`, causing faker to run.

## Approach
Runs faker on JSON property values rather than the JSON as a whole.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
