### PR TITLE
fix: grid column sorting

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -68,13 +68,13 @@
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.26\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Dynamics365.UIAutomation.Api, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.17139\lib\net46\Microsoft.Dynamics365.UIAutomation.Api.dll</HintPath>
+      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.23435\lib\net46\Microsoft.Dynamics365.UIAutomation.Api.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Dynamics365.UIAutomation.Api.UCI, Version=1.0.19282.1210, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.17139\lib\net46\Microsoft.Dynamics365.UIAutomation.Api.UCI.dll</HintPath>
+      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.23435\lib\net46\Microsoft.Dynamics365.UIAutomation.Api.UCI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Dynamics365.UIAutomation.Browser, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.17139\lib\net46\Microsoft.Dynamics365.UIAutomation.Browser.dll</HintPath>
+      <HintPath>..\..\packages\Dynamics365.UIAutomation.Api.9.1.0.23435\lib\net46\Microsoft.Dynamics365.UIAutomation.Browser.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.26\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/GridSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/GridSteps.cs
@@ -34,10 +34,11 @@
         /// Sorts by a column in the grid.
         /// </summary>
         /// <param name="column">The column to sort by.</param>
-        [When(@"I sort by '(.*)' in the grid")]
-        public static void WhenISortByInTheGrid(string column)
+        /// <param name="sortOption">The sort option.</param>
+        [When(@"I sort the '(.*)' column in the grid using the '(.*)' option")]
+        public static void WhenISortByInTheGrid(string column, string sortOption)
         {
-            XrmApp.Grid.Sort(column);
+            XrmApp.Grid.Sort(column, sortOption);
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/packages.config
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="BoDi" version="1.4.1" targetFramework="net462" />
   <package id="Cucumber.Messages" version="6.0.1" targetFramework="net462" />
-  <package id="Dynamics365.UIAutomation.Api" version="9.1.0.17139" targetFramework="net462" />
+  <package id="Dynamics365.UIAutomation.Api" version="9.1.0.23435" targetFramework="net462" />
   <package id="FluentAssertions" version="5.10.3" targetFramework="net462" />
   <package id="Gherkin" version="6.0.0" targetFramework="net462" />
   <package id="Google.Protobuf" version="3.7.0" targetFramework="net462" />

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/GridSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/GridSteps.feature
@@ -3,7 +3,8 @@
 	As a developer
 	I want to use pre-existing lookup bindings
 
-Scenario: Switch views for App loading grid
+Scenario: Sort the All Accounts view by Account Name A to Z
 	Given I am logged in to the 'Sales Team Member' app as 'an admin'
 	When I open the 'Accounts' sub area of the 'Customers' group
-	When I switch to the 'All Accounts' view in the grid
+	And I switch to the 'All Accounts' view in the grid
+	And I sort the 'Account Name' column in the grid using the 'Sort A to Z' option


### PR DESCRIPTION
## Purpose
Grid column sorting is fixed in a later version of EasyRepro than we were dependent on. Unfortunately, it was a breaking change - so users wouldn't have been able to fix this by updating the EasyRepro package dependency alone.

## Approach
Updates to the latest version of EasyRepro and updates the step binding to capture the additional parameter that is required.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
