### PR TITLE
fix: 'what's new' pop-ups intercepting clicks

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -1,6 +1,7 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Steps
 {
     using Microsoft.Dynamics365.UIAutomation.Browser;
+    using OpenQA.Selenium;
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -25,6 +26,16 @@
                 user.Password.ToSecureString());
 
             XrmApp.Navigation.OpenApp(appName);
+
+            CloseTeachingBubbles();
+        }
+
+        private static void CloseTeachingBubbles()
+        {
+            foreach (var closeButton in Driver.FindElements(By.ClassName("ms-TeachingBubble-closebutton")))
+            {
+                closeButton.Click();
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
A 'What's New' pop-up, appearing since the October 2020 wave 2 release, has been intercepting clicks.

## Approach
Closes any such pop-ups on login (if they exist).

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
