### PR TITLE
feat: test data setup as named user

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -37,6 +37,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.29" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
     <PackageReference Include="Microsoft.SourceLink.Common" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ClientCredentials.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ClientCredentials.cs
@@ -1,0 +1,32 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
+{
+    using YamlDotNet.Serialization;
+
+    /// <summary>
+    /// Configuration for the test application user.
+    /// </summary>
+    public class ClientCredentials
+    {
+        private string tenantId;
+        private string clientId;
+        private string clientSecret;
+
+        /// <summary>
+        /// Gets or sets the tenant ID of the test application user app registration.
+        /// </summary>
+        [YamlMember(Alias = "tenantId")]
+        public string TenantId { get => ConfigHelper.GetEnvironmentVariableIfExists(this.tenantId); set => this.tenantId = value; }
+
+        /// <summary>
+        /// Gets or sets the client ID of the test application user app registration.
+        /// </summary>
+        [YamlMember(Alias = "clientId")]
+        public string ClientId { get => ConfigHelper.GetEnvironmentVariableIfExists(this.clientId); set => this.clientId = value; }
+
+        /// <summary>
+        /// Gets or sets a client secret or the name of an environment variable containing the client secret of the test application user app registration.
+        /// </summary>
+        [YamlMember(Alias = "clientSecret")]
+        public string ClientSecret { get => ConfigHelper.GetEnvironmentVariableIfExists(this.clientSecret); set => this.clientSecret = value; }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ConfigHelper.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ConfigHelper.cs
@@ -1,0 +1,27 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
+{
+    using System;
+
+    /// <summary>
+    /// Helper methods for configuration classes.
+    /// </summary>
+    public static class ConfigHelper
+    {
+        /// <summary>
+        /// Returns the value of an environment variable if it exists. Alternatively, returns the passed in value.
+        /// </summary>
+        /// <param name="value">The value which may be the name of an environment variable.</param>
+        /// <returns>The environment variable value (if found) or the passed in value.</returns>
+        public static string GetEnvironmentVariableIfExists(string value)
+        {
+            var environmentVariableValue = Environment.GetEnvironmentVariable(value);
+
+            if (!string.IsNullOrEmpty(environmentVariableValue))
+            {
+                return environmentVariableValue;
+            }
+
+            return value;
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -27,15 +27,11 @@
             this.BrowserOptions = new BrowserOptions();
         }
 
-#pragma warning disable CA1056 // Uri properties should not be strings
-
         /// <summary>
-        /// Gets or sets the URL of the target Dynamics 365 instance.
+        /// Sets the URL of the target Dynamics 365 instance.
         /// </summary>
         [YamlMember(Alias = "url")]
-        public string Url { get; set; }
-
-#pragma warning restore CA1056 // Uri properties should not be strings
+        public string Url { private get; set; }
 
         /// <summary>
         /// Gets or sets the browser options to use for running tests.
@@ -43,15 +39,17 @@
         [YamlMember(Alias = "browserOptions")]
         public BrowserOptions BrowserOptions { get; set; }
 
-#pragma warning disable CA2227 // Collection properties should be read only
-
         /// <summary>
         /// Gets or sets users that tests can be run as.
         /// </summary>
         [YamlMember(Alias = "users")]
         public List<UserConfiguration> Users { get; set; }
 
-#pragma warning restore CA2227 // Collection properties should be read only
+        /// <summary>
+        /// Gets or sets application user client ID and client secret for performing certain operations (e.g. impersonating other users during test data creation).
+        /// </summary>
+        [YamlMember(Alias = "applicationUser")]
+        public ClientCredentials ApplicationUser { get; set; }
 
         /// <summary>
         /// Gets the target URL.
@@ -59,9 +57,7 @@
         /// <returns>The URL of the test environment.</returns>
         public Uri GetTestUrl()
         {
-            var urlEnvironmentVariable = Environment.GetEnvironmentVariable(this.Url);
-
-            return string.IsNullOrEmpty(urlEnvironmentVariable) ? new Uri(this.Url) : new Uri(urlEnvironmentVariable);
+            return new Uri(ConfigHelper.GetEnvironmentVariableIfExists(this.Url));
         }
 
         /// <summary>
@@ -73,15 +69,7 @@
         {
             try
             {
-                var user = this.Users.First(u => u.Alias == userAlias);
-
-                var usernameEnvironmentVariable = Environment.GetEnvironmentVariable(user.Username);
-                user.Username = string.IsNullOrEmpty(usernameEnvironmentVariable) ? user.Username : usernameEnvironmentVariable;
-
-                var passwordEnvironmentVariable = Environment.GetEnvironmentVariable(user.Password);
-                user.Password = string.IsNullOrEmpty(passwordEnvironmentVariable) ? user.Password : passwordEnvironmentVariable;
-
-                return user;
+                return this.Users.First(u => u.Alias == userAlias);
             }
             catch (Exception ex)
             {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
@@ -7,17 +7,20 @@
     /// </summary>
     public class UserConfiguration
     {
+        private string username;
+        private string password;
+
         /// <summary>
         /// Gets or sets the username of the user.
         /// </summary>
         [YamlMember(Alias = "username")]
-        public string Username { get; set; }
+        public string Username { get => ConfigHelper.GetEnvironmentVariableIfExists(this.username); set => this.username = value; }
 
         /// <summary>
         /// Gets or sets the password of the user.
         /// </summary>
         [YamlMember(Alias = "password")]
-        public string Password { get; set; }
+        public string Password { get => ConfigHelper.GetEnvironmentVariableIfExists(this.password); set => this.password = value; }
 
         /// <summary>
         /// Gets or sets the alias of the user (used to retrieve from configuration).

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -30,7 +30,14 @@
         {
             try
             {
-                TestDriver.DeleteTestData();
+                if (TestConfig.ApplicationUser != null)
+                {
+                    TestDriver.DeleteTestData(AccessToken);
+                }
+                else
+                {
+                    TestDriver.DeleteTestData();
+                }
             }
             catch (WebDriverException)
             {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -30,14 +30,7 @@
         {
             try
             {
-                if (TestConfig.ApplicationUser != null)
-                {
-                    TestDriver.DeleteTestData(AccessToken);
-                }
-                else
-                {
-                    TestDriver.DeleteTestData();
-                }
+                TestDriver.DeleteTestData();
             }
             catch (WebDriverException)
             {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
@@ -11,12 +11,26 @@
         /// Loads scenario test data.
         /// </summary>
         /// <param name="data">The data to load.</param>
+        /// <param name="username">The username of the user to impersonate.</param>
+        /// <param name="authToken">Auth token for the impersonating application user.</param>
+        void LoadTestDataAsUser(string data, string username, string authToken);
+
+        /// <summary>
+        /// Loads scenario test data.
+        /// </summary>
+        /// <param name="data">The data to load.</param>
         void LoadTestData(string data);
 
         /// <summary>
         /// Deletes scenario test data.
         /// </summary>
         void DeleteTestData();
+
+        /// <summary>
+        /// Deletes scenario test data using the access token to authenticate.
+        /// </summary>
+        /// <param name="accessToken">The access token to authenticate with.</param>
+        void DeleteTestData(string accessToken);
 
         /// <summary>
         /// Open a test record.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
@@ -8,12 +8,17 @@
     public interface ITestDriver
     {
         /// <summary>
+        /// Injects the driver onto the current page.
+        /// </summary>
+        /// <param name="authToken">The application user auth token (if configured).</param>
+        void InjectOnPage(string authToken);
+
+        /// <summary>
         /// Loads scenario test data.
         /// </summary>
         /// <param name="data">The data to load.</param>
         /// <param name="username">The username of the user to impersonate.</param>
-        /// <param name="authToken">Auth token for the impersonating application user.</param>
-        void LoadTestDataAsUser(string data, string username, string authToken);
+        void LoadTestDataAsUser(string data, string username);
 
         /// <summary>
         /// Loads scenario test data.
@@ -25,12 +30,6 @@
         /// Deletes scenario test data.
         /// </summary>
         void DeleteTestData();
-
-        /// <summary>
-        /// Deletes scenario test data using the access token to authenticate.
-        /// </summary>
-        /// <param name="accessToken">The access token to authenticate with.</param>
-        void DeleteTestData(string accessToken);
 
         /// <summary>
         /// Open a test record.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -100,7 +100,19 @@
         /// <summary>
         /// Gets provides utilities for test setup/teardown.
         /// </summary>
-        protected static ITestDriver TestDriver => testDriver ?? (testDriver = new TestDriver((IJavaScriptExecutor)Driver));
+        protected static ITestDriver TestDriver
+        {
+            get
+            {
+                if (testDriver == null)
+                {
+                    testDriver = new TestDriver((IJavaScriptExecutor)Driver);
+                    testDriver.InjectOnPage(TestConfig.ApplicationUser != null ? AccessToken : null);
+                }
+
+                return testDriver;
+            }
+        }
 
         /// <summary>
         /// Performs any cleanup necessary when quitting the WebBrowser.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -41,7 +41,7 @@
             {
                 var hostSegments = TestConfig.GetTestUrl().Host.Split('.');
 
-                return App.AcquireTokenForClient(new string[] { $"https://{hostSegments[0]}.api.{hostSegments[1]}.dynamics.com//.default" })
+                return GetApp().AcquireTokenForClient(new string[] { $"https://{hostSegments[0]}.api.{hostSegments[1]}.dynamics.com//.default" })
                     .ExecuteAsync()
                     .Result.AccessToken;
             }
@@ -103,30 +103,6 @@
         protected static ITestDriver TestDriver => testDriver ?? (testDriver = new TestDriver((IJavaScriptExecutor)Driver));
 
         /// <summary>
-        /// Gets the <see cref="IConfidentialClientApplication"/> used to authenticate as the configured application user.
-        /// </summary>
-        private static IConfidentialClientApplication App
-        {
-            get
-            {
-                if (TestConfig.ApplicationUser == null)
-                {
-                    throw new ConfigurationErrorsException("An application user has not been configured.");
-                }
-
-                if (app == null)
-                {
-                    app = ConfidentialClientApplicationBuilder.Create(TestConfig.ApplicationUser.ClientId)
-                        .WithTenantId(TestConfig.ApplicationUser.TenantId)
-                        .WithClientSecret(TestConfig.ApplicationUser.ClientSecret)
-                        .Build();
-                }
-
-                return app;
-            }
-        }
-
-        /// <summary>
         /// Performs any cleanup necessary when quitting the WebBrowser.
         /// </summary>
         protected static void Quit()
@@ -140,6 +116,27 @@
             xrmApp = null;
             client = null;
             testDriver = null;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IConfidentialClientApplication"/> used to authenticate as the configured application user.
+        /// </summary>
+        private static IConfidentialClientApplication GetApp()
+        {
+            if (TestConfig.ApplicationUser == null)
+            {
+                throw new ConfigurationErrorsException("An application user has not been configured.");
+            }
+
+            if (app == null)
+            {
+                app = ConfidentialClientApplicationBuilder.Create(TestConfig.ApplicationUser.ClientId)
+                    .WithTenantId(TestConfig.ApplicationUser.TenantId)
+                    .WithClientSecret(TestConfig.ApplicationUser.ClientSecret)
+                    .Build();
+            }
+
+            return app;
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/DataSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/DataSteps.cs
@@ -1,7 +1,9 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Steps
 {
+    using System.Configuration;
     using Capgemini.PowerApps.SpecFlowBindings;
     using Microsoft.Dynamics365.UIAutomation.Browser;
+    using Microsoft.Identity.Client;
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -30,6 +32,20 @@
         public static void GivenIHaveCreated(string fileName)
         {
             TestDriver.LoadTestData(TestDataRepository.GetTestData(fileName));
+        }
+
+        /// <summary>
+        /// Creates a test record as a given user.
+        /// </summary>
+        /// <param name="alias">The user alias.</param>
+        /// <param name="fileName">The name of the file containing the test record.</param>
+        [Given(@"'(.*)' has created '(.*)'")]
+        public static void GivenIHaveCreated(string alias, string fileName)
+        {
+            TestDriver.LoadTestDataAsUser(
+                TestDataRepository.GetTestData(fileName),
+                TestConfig.GetUser(alias).Username,
+                AccessToken);
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/DataSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/DataSteps.cs
@@ -44,8 +44,7 @@
         {
             TestDriver.LoadTestDataAsUser(
                 TestDataRepository.GetTestData(fileName),
-                TestConfig.GetUser(alias).Username,
-                AccessToken);
+                TestConfig.GetUser(alias).Username);
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -41,10 +41,22 @@
             this.ExecuteDriverFunctionAsync($"loadTestData(`{data}`)");
         }
 
+        /// <inheritdoc/>
+        public void LoadTestDataAsUser(string data, string username, string authToken)
+        {
+            this.ExecuteDriverFunctionAsync($"loadTestDataAsUser(`{data}`, '{username}', '{authToken}')");
+        }
+
         /// <inheritdoc cref="ITestDriver"/>
         public void DeleteTestData()
         {
             this.ExecuteDriverFunctionAsync("deleteTestData()");
+        }
+
+        /// <inheritdoc cref="ITestDriver"/>
+        public void DeleteTestData(string accessToken)
+        {
+            this.ExecuteDriverFunctionAsync($"deleteTestData('{accessToken}')");
         }
 
         /// <inheritdoc cref="ITestDriver"/>
@@ -87,7 +99,7 @@
         {
             this.javascriptExecutor.ExecuteScript(
                 $"{File.ReadAllText(this.FilePath)}\n" +
-                $@"var recordRepository = new {LibraryNamespace}.RecordRepository(Xrm.WebApi.online);
+                $@"var recordRepository = new {LibraryNamespace}.CurrentUserRecordRepository(Xrm.WebApi.online);
                    var metadataRepository = new {LibraryNamespace}.MetadataRepository(Xrm.WebApi.online);
                    var deepInsertService = new {LibraryNamespace}.DeepInsertService(metadataRepository, recordRepository);
                    var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()]);

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
+    using System.Text;
     using Microsoft.Xrm.Sdk;
     using OpenQA.Selenium;
 
@@ -29,11 +30,35 @@
         public TestDriver(IJavaScriptExecutor javascriptExecutor)
         {
             this.javascriptExecutor = javascriptExecutor;
-
-            this.Initialise();
         }
 
         private string FilePath => this.path ?? (this.path = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), DriverScriptPath));
+
+        /// <inheritdoc/>
+        public void InjectOnPage(string authToken)
+        {
+            var scriptBuilder = new StringBuilder();
+            scriptBuilder.AppendLine(File.ReadAllText(this.FilePath));
+            scriptBuilder.AppendLine($@"var recordRepository = new {LibraryNamespace}.CurrentUserRecordRepository(Xrm.WebApi.online);
+                   var metadataRepository = new {LibraryNamespace}.MetadataRepository(Xrm.WebApi.online);
+                   var deepInsertService = new {LibraryNamespace}.DeepInsertService(metadataRepository, recordRepository);");
+
+            if (!string.IsNullOrEmpty(authToken))
+            {
+                scriptBuilder.AppendLine(
+                    $@"var appUserRecordRepository = new {LibraryNamespace}.AuthenticatedRecordRepository(metadataRepository, '{authToken}');
+                       var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()], appUserRecordRepository);");
+            }
+            else
+            {
+                scriptBuilder.AppendLine(
+                    $"var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()]);");
+            }
+
+            scriptBuilder.AppendLine($"{TestDriverReference} = new {LibraryNamespace}.Driver(dataManager);");
+
+            this.javascriptExecutor.ExecuteScript(scriptBuilder.ToString());
+        }
 
         /// <inheritdoc cref="ITestDriver"/>
         public void LoadTestData(string data)
@@ -42,21 +67,15 @@
         }
 
         /// <inheritdoc/>
-        public void LoadTestDataAsUser(string data, string username, string authToken)
+        public void LoadTestDataAsUser(string data, string username)
         {
-            this.ExecuteDriverFunctionAsync($"loadTestDataAsUser(`{data}`, '{username}', '{authToken}')");
+            this.ExecuteDriverFunctionAsync($"loadTestDataAsUser(`{data}`, '{username}')");
         }
 
         /// <inheritdoc cref="ITestDriver"/>
         public void DeleteTestData()
         {
             this.ExecuteDriverFunctionAsync("deleteTestData()");
-        }
-
-        /// <inheritdoc cref="ITestDriver"/>
-        public void DeleteTestData(string accessToken)
-        {
-            this.ExecuteDriverFunctionAsync($"deleteTestData('{accessToken}')");
         }
 
         /// <inheritdoc cref="ITestDriver"/>
@@ -93,17 +112,6 @@
             }
 
             return result;
-        }
-
-        private void Initialise()
-        {
-            this.javascriptExecutor.ExecuteScript(
-                $"{File.ReadAllText(this.FilePath)}\n" +
-                $@"var recordRepository = new {LibraryNamespace}.CurrentUserRecordRepository(Xrm.WebApi.online);
-                   var metadataRepository = new {LibraryNamespace}.MetadataRepository(Xrm.WebApi.online);
-                   var deepInsertService = new {LibraryNamespace}.DeepInsertService(metadataRepository, recordRepository);
-                   var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()]);
-                   {TestDriverReference} = new {LibraryNamespace}.Driver(dataManager);");
         }
     }
 }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Data/a different team.json
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Data/a different team.json
@@ -1,0 +1,5 @@
+{
+  "@logicalName": "team",
+  "@alias": "the team",
+  "name": "A different team"
+}

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DataSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DataSteps.feature
@@ -15,3 +15,6 @@ Scenario: Set a lookup with an alias
 Scenario: Generate data at run-time with faker
 	And I have created 'data decorated with faker moustache syntax'
 	And I have opened 'the faked record'
+
+Scenario: Generate data as a named user
+	And 'an aliased user' has created 'a record with an alias'

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DialogSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DialogSteps.feature
@@ -27,7 +27,7 @@ Scenario: Assign to user on assign dialog
 Scenario: Assign to team on assign dialog
 	Given I have created 'a different team'
 	When I select the 'Assign' command
-	And I assign to a team named 'the team' on the assign dialog
+	And I assign to a team named 'A different team' on the assign dialog
 
 Scenario: Close warning dialog
 	When I select the 'Show Error Dialog' command

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DialogSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/DialogSteps.feature
@@ -25,9 +25,9 @@ Scenario: Assign to user on assign dialog
 	And I assign to a user named 'Power Apps Checker Application' on the assign dialog
 
 Scenario: Assign to team on assign dialog
-	Given I have created 'a team'
+	Given I have created 'a different team'
 	When I select the 'Assign' command
-	And I assign to a team named 'A team' on the assign dialog
+	And I assign to a team named 'the team' on the assign dialog
 
 Scenario: Close warning dialog
 	When I select the 'Show Error Dialog' command

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -5,7 +5,13 @@ browserOptions:
   width: 1920
   height: 1080
   startMaximized: false
+applicationUser:
+  tenantId: POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID
+  clientId: POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID
+  clientSecret: POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTSECRET
 users: 
   - username: POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME
     password: POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD
     alias: an admin
+  - username: POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME
+    alias: an aliased user

--- a/driver/src/data/createOptions.ts
+++ b/driver/src/data/createOptions.ts
@@ -1,0 +1,4 @@
+export interface CreateOptions {
+  authToken: string;
+  userToImpersonate: string
+}

--- a/driver/src/data/createOptions.ts
+++ b/driver/src/data/createOptions.ts
@@ -1,4 +1,3 @@
 export interface CreateOptions {
-  authToken: string;
   userToImpersonate: string
 }

--- a/driver/src/data/deepInsertService.ts
+++ b/driver/src/data/deepInsertService.ts
@@ -1,6 +1,6 @@
 import { MetadataRepository, RecordRepository } from '../repositories';
 import { DeepInsertResponse } from './deepInsertResponse';
-import { Record } from './record';
+import Record from './record';
 
 /**
  * Parses deep insert objects and returns references to all created records.

--- a/driver/src/data/deepInsertService.ts
+++ b/driver/src/data/deepInsertService.ts
@@ -29,6 +29,8 @@ export default class DeepInsertService {
      *
      * @param {string} logicalName The entity logical name of the root record.
      * @param {Record} record The deep insert object.
+     * @param dataByAlias References to previously created records by alias.
+     * @param {RecordRepository} repository An optional repository to override the default.
      * @returns {Promise<DeepInsertResponse>} An async result with references to created records.
      * @memberof DeepInsertService
      */
@@ -36,7 +38,9 @@ export default class DeepInsertService {
     logicalName: string,
     record: Record,
     dataByAlias: { [alias: string]: Xrm.LookupValue },
+    repository?: RecordRepository,
   ): Promise<DeepInsertResponse> {
+    const repo = repository ?? this.recordRepository;
     const recordToCreate = record;
     const associatedRecords: { alias?: string, reference: Xrm.LookupValue }[] = [];
 
@@ -65,11 +69,11 @@ export default class DeepInsertService {
     const collRecordsByNavProp = DeepInsertService.getOneToManyRecords(recordToCreate);
     Object.keys(collRecordsByNavProp).forEach((collNavProp) => delete recordToCreate[collNavProp]);
 
-    const recordToCreateRef = await this.recordRepository.upsertRecord(logicalName, recordToCreate);
+    const recordToCreateRef = await repo.upsertRecord(logicalName, recordToCreate);
 
     await Promise.all(Object.keys(collRecordsByNavProp).map(async (collNavProp) => {
       const result = await this.createCollectionRecords(
-        logicalName, recordToCreateRef, collRecordsByNavProp, collNavProp, dataByAlias,
+        logicalName, recordToCreateRef, collRecordsByNavProp, collNavProp, dataByAlias, repo,
       );
       associatedRecords.push(...result);
     }));
@@ -148,6 +152,7 @@ export default class DeepInsertService {
     navPropMap: { [navigationProperty: string]: Record[] },
     collNavProp: string,
     refsByAlias: { [alias: string]: Xrm.LookupValue },
+    repository: RecordRepository,
   ): Promise<{ alias?: string, reference: Xrm.LookupValue }[]> {
     const relMetadata = await this.metadataRepository.getRelationshipMetadata(collNavProp);
     const set = await this.metadataRepository.getEntitySetForEntity(logicalName);
@@ -160,7 +165,15 @@ export default class DeepInsertService {
 
     const entity = relMetadata.Entity1LogicalName !== logicalName
       ? relMetadata.Entity1LogicalName : relMetadata.Entity2LogicalName;
-    return this.createManyToManyRecords(entity, collNavProp, navPropMap, parent, refsByAlias);
+
+    return this.createManyToManyRecords(
+      entity,
+      collNavProp,
+      navPropMap,
+      parent,
+      refsByAlias,
+      repository,
+    );
   }
 
   private async createOneToManyRecords(
@@ -191,11 +204,12 @@ export default class DeepInsertService {
     navPropMap: { [navProp: string]: Record[] },
     parent: Xrm.LookupValue,
     createdRecordsByAlias: { [alias: string]: Xrm.LookupValue },
+    repository: RecordRepository,
   ): Promise<{ alias?: string, reference: Xrm.LookupValue }[]> {
     const result = await Promise.all(navPropMap[navProp].map(async (manyToManyRecord) => {
       const response = await this.deepInsert(entity, manyToManyRecord, createdRecordsByAlias);
 
-      await this.recordRepository.associateManyToManyRecords(
+      await repository.associateManyToManyRecords(
         parent,
         [response.record.reference],
         navProp,

--- a/driver/src/data/fakerPreprocessor.ts
+++ b/driver/src/data/fakerPreprocessor.ts
@@ -1,6 +1,6 @@
 import * as faker from 'faker';
 import Preprocessor from './preprocessor';
-import { Record } from './record';
+import Record from './record';
 
 export default class FakerPreprocessor extends Preprocessor {
   // eslint-disable-next-line class-methods-use-this

--- a/driver/src/data/index.ts
+++ b/driver/src/data/index.ts
@@ -1,7 +1,7 @@
 export { default as DataManager } from './dataManager';
 export { default as DeepInsertService } from './deepInsertService';
 export { DeepInsertResponse } from './deepInsertResponse';
-export { Record } from './record';
+export { default as Record } from './record';
 export { TestRecord } from './testRecord';
 export { default as Preprocessor } from './preprocessor';
 export { default as FakerPreprocessor } from './fakerPreprocessor';

--- a/driver/src/data/preprocessor.ts
+++ b/driver/src/data/preprocessor.ts
@@ -1,4 +1,4 @@
-import { Record } from './record';
+import Record from './record';
 
 export default abstract class Preprocessor {
   abstract preprocess(data: Record): Record;

--- a/driver/src/data/record.ts
+++ b/driver/src/data/record.ts
@@ -1,3 +1,3 @@
-export interface Record {
+export default interface Record {
   [attribute: string]: number | string | unknown | unknown[];
 }

--- a/driver/src/data/testRecord.ts
+++ b/driver/src/data/testRecord.ts
@@ -1,4 +1,4 @@
-import { Record } from './record';
+import Record from './record';
 
 export interface TestRecord extends Record {
   '@alias': string;

--- a/driver/src/driver.ts
+++ b/driver/src/driver.ts
@@ -1,5 +1,4 @@
 import { DataManager } from './data';
-import { CreateOptions } from './data/createOptions';
 import { TestRecord } from './data/testRecord';
 
 /**
@@ -38,33 +37,27 @@ export default class Driver {
    *
    * @param json a JSON object.
    * @param userToImpersonate The username of the user to impersonate.
-   * @param authToken The auth token of the impersonating user.
    */
   public async loadTestDataAsUser(
     json: string,
     userToImpersonate: string,
-    authToken: string,
   ) {
     if (!userToImpersonate) {
       throw new Error('You have not provided the username of the user to impersonate.');
     }
-    if (!authToken) {
-      throw new Error('You have not provided the auth token of the impersonating user.');
-    }
+
     const testRecord = JSON.parse(json) as TestRecord;
     const logicalName = testRecord['@logicalName'];
-    const opts: CreateOptions = { authToken, userToImpersonate };
 
-    return this.dataManager.createData(logicalName, testRecord, opts);
+    return this.dataManager.createData(logicalName, testRecord, { userToImpersonate });
   }
 
   /**
      * Deletes data that has been created as a result of any requests to load  @see loadJsonData
-     * @param authToken An optional auth token to use when deleting test data.
      * @memberof Driver
      */
-  public deleteTestData(authToken?: string): Promise<(Xrm.LookupValue | void)[]> {
-    return this.dataManager.cleanup(authToken);
+  public deleteTestData(): Promise<(Xrm.LookupValue | void)[]> {
+    return this.dataManager.cleanup();
   }
 
   /**

--- a/driver/src/driver.ts
+++ b/driver/src/driver.ts
@@ -1,4 +1,5 @@
 import { DataManager } from './data';
+import { CreateOptions } from './data/createOptions';
 import { TestRecord } from './data/testRecord';
 
 /**
@@ -29,16 +30,41 @@ export default class Driver {
   public async loadTestData(json: string): Promise<Xrm.LookupValue> {
     const testRecord = JSON.parse(json) as TestRecord;
     const logicalName = testRecord['@logicalName'];
+
     return this.dataManager.createData(logicalName, testRecord);
   }
 
   /**
+   *
+   * @param json a JSON object.
+   * @param userToImpersonate The username of the user to impersonate.
+   * @param authToken The auth token of the impersonating user.
+   */
+  public async loadTestDataAsUser(
+    json: string,
+    userToImpersonate: string,
+    authToken: string,
+  ) {
+    if (!userToImpersonate) {
+      throw new Error('You have not provided the username of the user to impersonate.');
+    }
+    if (!authToken) {
+      throw new Error('You have not provided the auth token of the impersonating user.');
+    }
+    const testRecord = JSON.parse(json) as TestRecord;
+    const logicalName = testRecord['@logicalName'];
+    const opts: CreateOptions = { authToken, userToImpersonate };
+
+    return this.dataManager.createData(logicalName, testRecord, opts);
+  }
+
+  /**
      * Deletes data that has been created as a result of any requests to load  @see loadJsonData
-     *
+     * @param authToken An optional auth token to use when deleting test data.
      * @memberof Driver
      */
-  public deleteTestData(): Promise<(Xrm.LookupValue | void)[]> {
-    return this.dataManager.cleanup();
+  public deleteTestData(authToken?: string): Promise<(Xrm.LookupValue | void)[]> {
+    return this.dataManager.cleanup(authToken);
   }
 
   /**

--- a/driver/src/index.ts
+++ b/driver/src/index.ts
@@ -1,3 +1,3 @@
 export { default as Driver } from './driver';
 export { DataManager, DeepInsertService, FakerPreprocessor } from './data';
-export { RecordRepository, MetadataRepository } from './repositories';
+export { CurrentUserRecordRepository, MetadataRepository } from './repositories';

--- a/driver/src/index.ts
+++ b/driver/src/index.ts
@@ -1,3 +1,3 @@
 export { default as Driver } from './driver';
 export { DataManager, DeepInsertService, FakerPreprocessor } from './data';
-export { CurrentUserRecordRepository, MetadataRepository } from './repositories';
+export { CurrentUserRecordRepository, MetadataRepository, AuthenticatedRecordRepository } from './repositories';

--- a/driver/src/repositories/authenticatedRecordRepository.ts
+++ b/driver/src/repositories/authenticatedRecordRepository.ts
@@ -34,6 +34,14 @@ export default class AuthenticatedRecordRepository implements RecordRepository {
   }
 
   /**
+   * Sets the user to impersonate.
+   * @param userToImpersonateId The ID of the user to impersonate.
+   */
+  public setImpersonatedUserId(userToImpersonateId: string) {
+    this.headers.CallerObjectId = userToImpersonateId;
+  }
+
+  /**
    * Retrieves a record.
    * @param logicalName The logical name of the record to retrieve.
    * @param id The ID of the record to retrieve.

--- a/driver/src/repositories/authenticatedRecordRepository.ts
+++ b/driver/src/repositories/authenticatedRecordRepository.ts
@@ -1,0 +1,184 @@
+import MetadataRepository from './metadataRepository';
+import RecordRepository from './recordRepository';
+import Record from '../data/record';
+
+/**
+ * Repository to handle CRUD operations for entities.
+ *
+ * @export
+ * @class RecordRepository
+ * @extends {Repository}
+ */
+export default class AuthenticatedRecordRepository implements RecordRepository {
+  private readonly headers: {[header:string]: string};
+
+  private readonly metadataRepo: MetadataRepository;
+
+  /**
+   * Creates an instance of AuthenticatedRecordRepository.
+   * @param metadataRepo A metadata repository.
+   * @param authToken The auth token for the impersonating user.
+   * @param userToImpersonateId An optional ID for an impersonated user.
+   */
+  constructor(metadataRepo: MetadataRepository, authToken: string, userToImpersonateId?: string) {
+    this.metadataRepo = metadataRepo;
+
+    this.headers = {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    };
+
+    if (userToImpersonateId) {
+      this.headers.CallerObjectId = userToImpersonateId;
+    }
+  }
+
+  /**
+   * Retrieves a record.
+   * @param logicalName The logical name of the record to retrieve.
+   * @param id The ID of the record to retrieve.
+   * @param query The query string.
+   */
+  public async retrieveRecord(logicalName: string, id: string, query?: string): Promise<any> {
+    const entitySet = await this.metadataRepo.getEntitySetForEntity(logicalName);
+    const res = await fetch(`api/data/v9.1/${entitySet}(${id})${query}`, { headers: this.headers });
+
+    await AuthenticatedRecordRepository.checkResponseForError(res);
+
+    return res.json();
+  }
+
+  /**
+   * Retrieves multiple records.
+   * @param logicalName The logical name of the records to retrieve.
+   * @param query The query string.
+   */
+  public async retrieveMultipleRecords(logicalName: string, query?: string): Promise<any> {
+    const entitySet = await this.metadataRepo.getEntitySetForEntity(logicalName);
+    const res = await fetch(`api/data/v9.1/${entitySet}${query}`, { headers: this.headers });
+
+    await AuthenticatedRecordRepository.checkResponseForError(res);
+
+    return res.json();
+  }
+
+  /**
+     * Creates an entity record.
+     *
+     * @param {string} logicalName A logical name for the entity to create.
+     * @param {Record} record A record to create.
+     * @returns {Xrm.LookupValue} An entity reference to the created entity.
+     * @memberof RecordRepository
+     */
+  public async createRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue> {
+    const entitySet = await this.metadataRepo.getEntitySetForEntity(logicalName);
+    const res = await fetch(`api/data/v9.1/${entitySet}`, {
+      headers: this.headers,
+      body: JSON.stringify(record),
+      method: 'POST',
+    });
+
+    await AuthenticatedRecordRepository.checkResponseForError(res);
+
+    const id = res.headers.get('OData-EntityId')!.match(/\((.*)\)/)![1];
+    return { entityType: logicalName, id };
+  }
+
+  /**
+     * Upserts an entity record.
+     * @param {string} logicalName A logical name for the entity to upsert.
+     * @param {Record} record A record to upsert.
+     * @returns {Xrm.LookupValue} An entity reference to the upserted entity.
+     * @memberof RecordRepository
+     */
+  public async upsertRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue> {
+    if (!record['@key']) {
+      return this.createRecord(logicalName, record);
+    }
+
+    const retrieveResponse = await this.retrieveMultipleRecords(
+      logicalName,
+      `?$filter=${record['@key']} eq '${record[record['@key'] as string]}'&$select=${logicalName}id`,
+    );
+
+    if (retrieveResponse.entities.length > 0) {
+      const id = retrieveResponse.entities[0][`${logicalName}id`];
+      await this.updateRecord(logicalName, id, record);
+
+      return { entityType: logicalName, id };
+    }
+
+    return this.createRecord(logicalName, record);
+  }
+
+  /**
+     * Deletes an entity record.
+     *
+     * @param {Xrm.LookupValue} ref A reference to the entity to delete.
+     * @returns {Xrm.LookupValue} A reference to the deleted entity.
+     * @memberof RecordRepository
+     */
+  public async deleteRecord(ref: Xrm.LookupValue): Promise<Xrm.LookupValue> {
+    const entitySet = await this.metadataRepo.getEntitySetForEntity(ref.entityType);
+    const res = await fetch(`api/data/v9.1/${entitySet}(${ref.id})`,
+      {
+        headers: this.headers,
+        method: 'DELETE',
+      });
+
+    await AuthenticatedRecordRepository.checkResponseForError(res);
+
+    return ref;
+  }
+
+  /**
+     * Associates two records in a N:N Relationship.
+     *
+     * @param {Xrm.LookupValue} primaryRecord The Primary Record to associate.
+     * @param {Xrm.LookupValue[]} relatedRecords The Related Records to associate.
+     * @param {string} relationship The N:N Relationship Name.
+     * @returns {Xrm.ExecuteResponse} The Response from the execute request.
+     * @memberof RecordRepository
+     */
+  public async associateManyToManyRecords(
+    primaryRecord: Xrm.LookupValue,
+    relatedRecords: Xrm.LookupValue[],
+    relationship: string,
+  ): Promise<void> {
+    const entitySetA = await this.metadataRepo.getEntitySetForEntity(primaryRecord.entityType);
+    const entitySetB = await this.metadataRepo.getEntitySetForEntity(relatedRecords[0].entityType);
+
+    await Promise.all(relatedRecords.map(async (r) => {
+      const res = await fetch(`api/data/v9.1/${entitySetA}(${primaryRecord.id})/${relationship}/$ref`,
+        {
+          headers: this.headers,
+          body: JSON.stringify({ '@odata.id': `${entitySetB}(${r.id})` }),
+          method: 'POST',
+        });
+
+      await AuthenticatedRecordRepository.checkResponseForError(res);
+    }));
+  }
+
+  private async updateRecord(logicalName: string, id: string, record: any) {
+    const entitySet = await this.metadataRepo.getEntitySetForEntity(logicalName);
+    const res = await fetch(`api/data/v9.1/${entitySet}(${id})`,
+      {
+        headers: this.headers,
+        body: JSON.stringify(record),
+        method: 'PATCH',
+      });
+
+    await AuthenticatedRecordRepository.checkResponseForError(res);
+
+    return res.json();
+  }
+
+  // eslint-disable-next-line no-undef
+  private static async checkResponseForError(res: Response) {
+    if (res.status >= 400) {
+      const json = await res.json();
+      throw new Error(`${json.error.code}: ${json.error.message}`);
+    }
+  }
+}

--- a/driver/src/repositories/currentUserRecordRepository.ts
+++ b/driver/src/repositories/currentUserRecordRepository.ts
@@ -1,0 +1,111 @@
+import RecordRepository from './recordRepository';
+import { Record } from '../data';
+import { AssociateRequest } from '../requests';
+
+/**
+ * Repository to handle CRUD operations for entities.
+ *
+ * @export
+ * @class RecordRepository
+ * @extends {Repository}
+ */
+export default class CurrentUserRecordRepository implements RecordRepository {
+  private readonly webApi: Xrm.WebApiOnline;
+
+  /**
+   * Creates an instance of CurrentUserRecordRepository.
+   * @param webApi The web API instance.
+   */
+  constructor(webApi: Xrm.WebApiOnline) {
+    this.webApi = webApi;
+  }
+
+  /**
+   * Retrieves a record.
+   * @param logicalName The logical name of the record to retrieve.
+   * @param id The ID of the record to retrieve.
+   * @param query The query string.
+   */
+  public async retrieveRecord(logicalName: string, id: string, query?: string): Promise<any> {
+    return this.webApi.retrieveRecord(logicalName, id, query);
+  }
+
+  /**
+   * Retrieves multiple records.
+   * @param logicalName The logical name of the records to retrieve.
+   * @param query The query string.
+   */
+  public async retrieveMultipleRecords(
+    logicalName: string,
+    query: string,
+  ): Promise<Xrm.RetrieveMultipleResult> {
+    return this.webApi.retrieveMultipleRecords(logicalName, query);
+  }
+
+  /**
+     * Creates an entity record.
+     *
+     * @param {string} logicalName A logical name for the entity to create.
+     * @param {Record} record A record to create.
+     * @returns {Xrm.LookupValue} An entity reference to the created entity.
+     * @memberof RecordRepository
+     */
+  public async createRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue> {
+    return this.webApi.createRecord(logicalName, record);
+  }
+
+  /**
+     * Upserts an entity record.
+     * @param {string} logicalName A logical name for the entity to upsert.
+     * @param {Record} record A record to upsert.
+     * @returns {Xrm.LookupValue} An entity reference to the upserted entity.
+     * @memberof RecordRepository
+     */
+  public async upsertRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue> {
+    if (!record['@key']) {
+      return this.webApi.createRecord(logicalName, record);
+    }
+
+    const retrieveResponse = await this.webApi.retrieveMultipleRecords(
+      logicalName,
+      `?$filter=${record['@key']} eq '${record[record['@key'] as string]}'&$select=${logicalName}id`,
+    );
+
+    if (retrieveResponse.entities.length > 0) {
+      const id = retrieveResponse.entities[0][`${logicalName}id`];
+      await this.webApi.updateRecord(logicalName, id, record);
+
+      return { entityType: logicalName, id };
+    }
+
+    return this.webApi.createRecord(logicalName, record);
+  }
+
+  /**
+     * Deletes an entity record.
+     *
+     * @param {Xrm.LookupValue} ref A reference to the entity to delete.
+     * @returns {Xrm.LookupValue} A reference to the deleted entity.
+     * @memberof RecordRepository
+     */
+  public async deleteRecord(ref: Xrm.LookupValue): Promise<Xrm.LookupValue> {
+    return this.webApi.deleteRecord(ref.entityType, ref.id) as unknown as Xrm.LookupValue;
+  }
+
+  /**
+     * Associates two records in a N:N Relationship.
+     *
+     * @param {Xrm.LookupValue} primaryRecord The Primary Record to associate.
+     * @param {Xrm.LookupValue[]} relatedRecords The Related Records to associate.
+     * @param {string} relationship The N:N Relationship Name.
+     * @returns {Xrm.ExecuteResponse} The Response from the execute request.
+     * @memberof RecordRepository
+     */
+  public async associateManyToManyRecords(
+    primaryRecord: Xrm.LookupValue,
+    relatedRecords: Xrm.LookupValue[],
+    relationship: string,
+  ): Promise<void> {
+    this.webApi.execute(new AssociateRequest(primaryRecord, relatedRecords, relationship));
+  }
+}

--- a/driver/src/repositories/index.ts
+++ b/driver/src/repositories/index.ts
@@ -1,3 +1,4 @@
 export { default as MetadataRepository } from './metadataRepository';
 export { default as RecordRepository } from './recordRepository';
-export { default as Repository } from './repository';
+export { default as CurrentUserRecordRepository } from './currentUserRecordRepository';
+export { default as AuthenticatedRecordRepository } from './authenticatedRecordRepository';

--- a/driver/src/repositories/metadataRepository.ts
+++ b/driver/src/repositories/metadataRepository.ts
@@ -1,5 +1,4 @@
 /* eslint-disable class-methods-use-this */
-import Repository from './repository';
 
 /**
  * Repository to handle requests for metadata.
@@ -8,7 +7,7 @@ import Repository from './repository';
  * @class MetadataRepository
  * @extends {Repository}
  */
-export default class MetadataRepository extends Repository {
+export default class MetadataRepository {
   private static readonly RelationshipMetadataSet = 'RelationshipDefinitions';
 
   private static readonly EntityMetadataSet = 'EntityDefinitions';
@@ -26,6 +25,7 @@ export default class MetadataRepository extends Repository {
     const response = await fetch(
       'api/data/v9.1/'
       + `${MetadataRepository.EntityMetadataSet}?$filter=LogicalName eq '${logicalName}'&$select=EntitySetName`,
+      { cache: 'force-cache' },
     );
     const result = await response.json();
 
@@ -45,6 +45,7 @@ export default class MetadataRepository extends Repository {
     const response = await fetch(
       'api/data/v9.1/'
       + `${MetadataRepository.EntityMetadataSet}(LogicalName='${logicalName}')/Attributes/Microsoft.Dynamics.CRM.LookupAttributeMetadata?$filter=LogicalName eq '${navigationProperty.toLowerCase()}'&$select=Targets`,
+      { cache: 'force-cache' },
     );
     const result = await response.json();
 
@@ -62,6 +63,7 @@ export default class MetadataRepository extends Repository {
     const response = await fetch(
       'api/data/v9.1/'
       + `${MetadataRepository.OneToNMetadataSet}?$filter=ReferencedEntityNavigationPropertyName eq '${navPropName}'&$select=ReferencingEntityNavigationPropertyName`,
+      { cache: 'force-cache' },
     );
     const result = await response.json();
 
@@ -78,6 +80,7 @@ export default class MetadataRepository extends Repository {
     const response = await fetch(
       'api/data/v9.1/'
       + `${MetadataRepository.RelationshipMetadataSet}(SchemaName='${relationshipSchemaName}')`,
+      { cache: 'force-cache' },
     );
 
     return response.json();

--- a/driver/src/repositories/recordRepository.ts
+++ b/driver/src/repositories/recordRepository.ts
@@ -1,79 +1,14 @@
-import Repository from './repository';
-import { Record } from '../data/record';
-import { AssociateRequest } from '../requests/index';
+import Record from '../data/record';
 
-/**
- * Repository to handle CRUD operations for entities.
- *
- * @export
- * @class RecordRepository
- * @extends {Repository}
- */
-export default class RecordRepository extends Repository {
-  /**
-     * Creates an entity record.
-     *
-     * @param {string} entityLogicalName A logical name for the entity to create.
-     * @param {Record} record A record to create.
-     * @returns {Xrm.LookupValue} An entity reference to the created entity.
-     * @memberof RecordRepository
-     */
-  public async createRecord(entityLogicalName: string, record: Record): Promise<Xrm.LookupValue> {
-    return this.webApi.createRecord(entityLogicalName, record);
-  }
-
-  /**
-     * Upserts an entity record.
-     * @param {string} entityLogicalName A logical name for the entity to upsert.
-     * @param {Record} record A record to upsert.
-     * @returns {Xrm.LookupValue} An entity reference to the upserted entity.
-     * @memberof RecordRepository
-     */
-  public async upsertRecord(entityLogicalName: string, record: Record): Promise<Xrm.LookupValue> {
-    if (!record['@key']) {
-      return this.webApi.createRecord(entityLogicalName, record);
-    }
-
-    const retrieveResponse = await this.webApi.retrieveMultipleRecords(
-      entityLogicalName,
-      `?$filter=${record['@key']} eq '${record[record['@key'] as string]}'&$select=${entityLogicalName}id`,
-    );
-
-    if (retrieveResponse.entities.length > 0) {
-      const id = retrieveResponse.entities[0][`${entityLogicalName}id`];
-      await this.webApi.updateRecord(entityLogicalName, id, record);
-
-      return { entityType: entityLogicalName, id };
-    }
-
-    return this.webApi.createRecord(entityLogicalName, record);
-  }
-
-  /**
-     * Deletes an entity record.
-     *
-     * @param {Xrm.LookupValue} ref A reference to the entity to delete.
-     * @returns {Xrm.LookupValue} A reference to the deleted entity.
-     * @memberof RecordRepository
-     */
-  public async deleteRecord(ref: Xrm.LookupValue): Promise<Xrm.LookupValue> {
-    return this.webApi.deleteRecord(ref.entityType, ref.id) as unknown as Xrm.LookupValue;
-  }
-
-  /**
-     * Associates two records in a N:N Relationship.
-     *
-     * @param {Xrm.LookupValue} primaryRecord The Primary Record to associate.
-     * @param {Xrm.LookupValue[]} relatedRecords The Related Records to associate.
-     * @param {string} relationship The N:N Relationship Name.
-     * @returns {Xrm.ExecuteResponse} The Response from the execute request.
-     * @memberof RecordRepository
-     */
-  public async associateManyToManyRecords(
+export default interface RecordRepository {
+  retrieveRecord(logicalName: string, id:string, query?: string): Promise<any>;
+  retrieveMultipleRecords(logicalName: string, query?: string): Promise<Xrm.RetrieveMultipleResult>;
+  createRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue>;
+  upsertRecord(logicalName: string, record: Record): Promise<Xrm.LookupValue>;
+  deleteRecord(ref: Xrm.LookupValue): Promise<Xrm.LookupValue>;
+  associateManyToManyRecords(
     primaryRecord: Xrm.LookupValue,
     relatedRecords: Xrm.LookupValue[],
     relationship: string,
-  ): Promise<Xrm.ExecuteResponse> {
-    return this.webApi.execute(new AssociateRequest(primaryRecord, relatedRecords, relationship));
-  }
+  ): Promise<void>;
 }

--- a/driver/src/repositories/repository.ts
+++ b/driver/src/repositories/repository.ts
@@ -1,7 +1,0 @@
-export default abstract class Repository {
-  protected readonly webApi: Xrm.WebApiOnline;
-
-  constructor(webApi: Xrm.WebApiOnline) {
-    this.webApi = webApi;
-  }
-}

--- a/driver/test/data/dataManager.spec.ts
+++ b/driver/test/data/dataManager.spec.ts
@@ -1,17 +1,21 @@
 import { DataManager, DeepInsertService } from '../../src/data';
-import { RecordRepository } from '../../src/repositories';
+import { AuthenticatedRecordRepository, CurrentUserRecordRepository } from '../../src/repositories';
 
 describe('TestDriver', () => {
-  let recordRepository: jasmine.SpyObj<RecordRepository>;
+  let currentUserRecordRepo: jasmine.SpyObj<CurrentUserRecordRepository>;
+  let appUserRecordRepo: jasmine.SpyObj<AuthenticatedRecordRepository>;
   let deepInsertService: jasmine.SpyObj<DeepInsertService>;
   let dataManager: DataManager;
 
   beforeEach(() => {
-    recordRepository = jasmine.createSpyObj<RecordRepository>(
-      'RecordRepository', ['createRecord', 'deleteRecord'],
+    currentUserRecordRepo = jasmine.createSpyObj<CurrentUserRecordRepository>(
+      'CurrentUserRecordRepository', ['createRecord', 'deleteRecord', 'retrieveMultipleRecords'],
+    );
+    appUserRecordRepo = jasmine.createSpyObj<AuthenticatedRecordRepository>(
+      'AuthenticatedRecordRepository', ['createRecord', 'deleteRecord', 'setImpersonatedUserId'],
     );
     deepInsertService = jasmine.createSpyObj<DeepInsertService>('DeepInsertService', ['deepInsert']);
-    dataManager = new DataManager(recordRepository, deepInsertService);
+    dataManager = new DataManager(currentUserRecordRepo, deepInsertService, [], appUserRecordRepo);
   });
 
   describe('.createData(record)', () => {
@@ -45,6 +49,24 @@ describe('TestDriver', () => {
 
       expect(dataManager.refs).toEqual([rec.reference, ...assocRecs.map((r) => r.reference)]);
     });
+
+    it('uses the application user repository if a user to impersonate is passed', async () => {
+      const userToImpersonateId = 'user-id';
+      currentUserRecordRepo.retrieveMultipleRecords.and.resolveTo(
+        { entities: [{ azureactivedirectoryobjectid: 'user-id' }], nextLink: '' },
+      );
+      const records: { alias?: string, reference: Xrm.LookupValue } = {
+        reference: { entityType: 'account', id: '<account-id>' },
+      };
+      deepInsertService.deepInsert.and.resolveTo({ record: records, associatedRecords: [] });
+
+      await dataManager.createData('account', {}, { userToImpersonate: userToImpersonateId });
+
+      expect(appUserRecordRepo.setImpersonatedUserId).toHaveBeenCalledWith(userToImpersonateId);
+      expect(deepInsertService.deepInsert).toHaveBeenCalledWith(
+        jasmine.anything(), jasmine.anything(), jasmine.anything(), appUserRecordRepo,
+      );
+    });
   });
 
   describe('.cleanup()', () => {
@@ -69,29 +91,47 @@ describe('TestDriver', () => {
       await dataManager.cleanup();
 
       expect(
-        recordRepository.deleteRecord.calls.allArgs().find((args) => args[0].id === rootRecord.id),
+        appUserRecordRepo.deleteRecord.calls.allArgs().find(
+          (args) => args[0].id === rootRecord.id,
+        ),
       ).not.toBeNull();
     });
 
     it('deletes associated records', async () => {
       await dataManager.cleanup();
 
-      expect(recordRepository.deleteRecord.calls.count()).toBe(2);
+      expect(appUserRecordRepo.deleteRecord.calls.count()).toBe(2);
     });
 
     it('does not attempt to delete previously deleted records', async () => {
       await dataManager.cleanup();
       await dataManager.cleanup();
 
-      expect(recordRepository.deleteRecord.calls.count()).toBe(2);
+      expect(appUserRecordRepo.deleteRecord.calls.count()).toBe(2);
     });
 
     it('retries failed delete requests', async () => {
-      recordRepository.deleteRecord.and.throwError('Failed to delete');
+      appUserRecordRepo.deleteRecord.and.throwError('Failed to delete');
 
       dataManager.cleanup();
 
-      expect(recordRepository.deleteRecord.calls.count()).toBe(6);
+      expect(appUserRecordRepo.deleteRecord.calls.count()).toBe(6);
+    });
+
+    it('uses the current user repository if no app user repository is set', async () => {
+      const dm = new DataManager(currentUserRecordRepo, deepInsertService);
+      const mockDeepInsertResponse = Promise.resolve(
+        {
+          associatedRecords: [{ reference: associatedRecord, alias: associatedRecordAlias }],
+          record: { reference: rootRecord, alias: rootRecordAlias },
+        },
+      );
+      deepInsertService.deepInsert.and.returnValue(mockDeepInsertResponse);
+      await dm.createData('', {});
+
+      await dm.cleanup();
+
+      expect(currentUserRecordRepo.deleteRecord.calls.count()).toBe(2);
     });
   });
 });

--- a/driver/test/data/deepInsertService.spec.ts
+++ b/driver/test/data/deepInsertService.spec.ts
@@ -229,5 +229,13 @@ describe('DeepInsertService', () => {
 
       expect(entityReference.record.reference).toBe(expectedEntityReference);
     });
+
+    it('overrides the default repository with the one passed as an argument (if provided)', async () => {
+      const newRecordRepo = jasmine.createSpyObj<RecordRepository>('RecordRepository', ['upsertRecord']);
+
+      await deepInsertService.deepInsert('account', { name: 'Sample Account' }, {}, newRecordRepo);
+
+      expect(newRecordRepo.upsertRecord).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/driver/test/driver.spec.ts
+++ b/driver/test/driver.spec.ts
@@ -1,3 +1,4 @@
+import { CreateOptions } from '../src/data/createOptions';
 import DataManager from '../src/data/dataManager';
 import Driver from '../src/driver';
 
@@ -7,6 +8,26 @@ describe('Driver', () => {
   beforeAll(() => {
     dataManager = jasmine.createSpyObj<DataManager>('DataManager', ['createData', 'cleanup', 'refs', 'refsByAlias']);
     driver = new Driver(dataManager);
+  });
+
+  describe('.loadTestDataAsUser(json, username, authToken)', () => {
+    it('throws if a username isn\'t provided', () => expectAsync(driver.loadTestDataAsUser('{}', '', 'token')).toBeRejectedWithError(/.*username.*/));
+
+    it('throws if a token isn\'t provided', () => expectAsync(driver.loadTestDataAsUser('{}', 'user@contoso.com', '')).toBeRejectedWithError(/.*token.*/));
+
+    it('passes CreateOptions to dataManager', async () => {
+      const userToImpersonate = 'user@contoso.com';
+      const authToken = 'token';
+      const expectedCreateOptions: CreateOptions = { authToken, userToImpersonate };
+
+      await driver.loadTestDataAsUser('{ "@logicalName": "contact" }', userToImpersonate, authToken);
+
+      expect(dataManager.createData).toHaveBeenCalledWith(
+        jasmine.anything(),
+        jasmine.anything(),
+        jasmine.objectContaining(expectedCreateOptions),
+      );
+    });
   });
 
   describe('.loadJsonData(json)', () => {

--- a/driver/test/driver.spec.ts
+++ b/driver/test/driver.spec.ts
@@ -10,17 +10,14 @@ describe('Driver', () => {
     driver = new Driver(dataManager);
   });
 
-  describe('.loadTestDataAsUser(json, username, authToken)', () => {
-    it('throws if a username isn\'t provided', () => expectAsync(driver.loadTestDataAsUser('{}', '', 'token')).toBeRejectedWithError(/.*username.*/));
-
-    it('throws if a token isn\'t provided', () => expectAsync(driver.loadTestDataAsUser('{}', 'user@contoso.com', '')).toBeRejectedWithError(/.*token.*/));
+  describe('.loadTestDataAsUser(json, username)', () => {
+    it('throws if a username isn\'t provided', () => expectAsync(driver.loadTestDataAsUser('{}', '')).toBeRejectedWithError(/.*username.*/));
 
     it('passes CreateOptions to dataManager', async () => {
       const userToImpersonate = 'user@contoso.com';
-      const authToken = 'token';
-      const expectedCreateOptions: CreateOptions = { authToken, userToImpersonate };
+      const expectedCreateOptions: CreateOptions = { userToImpersonate };
 
-      await driver.loadTestDataAsUser('{ "@logicalName": "contact" }', userToImpersonate, authToken);
+      await driver.loadTestDataAsUser('{ "@logicalName": "contact" }', userToImpersonate);
 
       expect(dataManager.createData).toHaveBeenCalledWith(
         jasmine.anything(),

--- a/driver/test/repositories/authenticatedUserRecordRepository.spec.ts
+++ b/driver/test/repositories/authenticatedUserRecordRepository.spec.ts
@@ -1,0 +1,118 @@
+import { AuthenticatedRecordRepository, MetadataRepository, RecordRepository } from '../../src/repositories/index';
+
+const fetchMock = require('fetch-mock/es5/client');
+
+describe('CurrentUserRecordRepository', () => {
+  const logicalName = 'account';
+
+  let recordRepo: RecordRepository;
+  let metadataRepo: jasmine.SpyObj<MetadataRepository>;
+  beforeEach(() => {
+    metadataRepo = jasmine.createSpyObj<MetadataRepository>('MetadataRepository',
+      [
+        'getEntitySetForEntity',
+        'getEntityForLookupProperty',
+        'getLookupPropertyForCollectionProperty',
+        'getRelationshipMetadata',
+      ]);
+    metadataRepo.getEntitySetForEntity.and.returnValues(Promise.resolve('accounts'), Promise.resolve('contacts'));
+    recordRepo = new AuthenticatedRecordRepository(metadataRepo, '', '');
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  describe('createRecord(entityLogicalName, record)', () => {
+    it('returns a reference to the created record', async () => {
+      const guid = 'bc148b3f-d7d7-4546-a3a8-d92ffd9a98c8';
+      fetchMock.mock('*', { headers: { 'OData-EntityId': `api/data/v9.1/accounts(${guid})` } });
+
+      const actualReference = await recordRepo.createRecord(logicalName, { });
+
+      expect(actualReference).toEqual({ entityType: logicalName, id: guid });
+    });
+  });
+
+  describe('retrieveRecord(entityLogicalName, id, query)', () => {
+    it('returns the retrieved record', async () => {
+      const expectedRecord = { accountid: 'account-id' };
+      fetchMock.mock('*', expectedRecord);
+
+      const actualRecord = await recordRepo.retrieveRecord('account', 'account-id');
+
+      expect(actualRecord).toEqual(expectedRecord);
+    });
+  });
+
+  describe('retrieveMultipleRecord(entityLogicalName, query)', () => {
+    it('returns the retrieved records', async () => {
+      const expectedResponse: Xrm.RetrieveMultipleResult = { entities: [], nextLink: '' };
+      fetchMock.mock('*', expectedResponse);
+
+      const actualResponse = await recordRepo.retrieveMultipleRecords('account', '?');
+
+      expect(actualResponse).toEqual(expectedResponse);
+    });
+  });
+
+  describe('upsertRecord(entityLogicalName, record)', () => {
+    const record = { '@key': 'keyfield', keyfield: 'Test Key' };
+
+    it('performs an update when a match is found on @key', async () => {
+      const matchedRecordId = '<account-id>';
+      const retrieveResult: Xrm.RetrieveMultipleResult = {
+        entities: [{ accountid: matchedRecordId }],
+        nextLink: '',
+      };
+      fetchMock.mock('*', retrieveResult);
+
+      const result = await recordRepo.upsertRecord(logicalName, record);
+
+      expect(result.id).toBe(matchedRecordId);
+    });
+
+    it('performs a create when no match is found on @key', async () => {
+      const retrieveResult: Xrm.RetrieveMultipleResult = {
+        entities: [],
+        nextLink: '',
+      };
+      const id = 'account-id';
+      fetchMock.get('*', retrieveResult);
+      fetchMock.post('*', { headers: { 'OData-EntityId': `api/data/v9.1/accounts(${id})` } });
+
+      const result = await recordRepo.upsertRecord(logicalName, {});
+
+      expect(result.id).toBe(id);
+    });
+  });
+
+  describe('deleteRecord(entityReference)', () => {
+    it('returns a reference to the deleted record', async () => {
+      const entityReference: Xrm.LookupValue = {
+        entityType: 'account',
+        id: '<account-id>',
+      };
+      fetchMock.mock('*', { status: 200 });
+
+      const result = await recordRepo.deleteRecord(entityReference);
+
+      expect(result).toEqual(entityReference);
+    });
+  });
+
+  describe('associateManyToManyRecords(primaryRecord, relatedRecord, relationshipName)', () => {
+    it('executes an associate request', async () => {
+      const primary: Xrm.LookupValue = { id: '<primary-id>', entityType: 'primaryentity' };
+      const related: Xrm.LookupValue[] = [{ id: '<related-id>', entityType: 'relatedentity' }];
+      const relationship = 'primary_related';
+      fetchMock.mock('*', { status: 200 });
+
+      await recordRepo.associateManyToManyRecords(primary, related, relationship);
+      const call = fetchMock.calls()[0];
+
+      expect(call[0]).toBe('/api/data/v9.1/accounts(%3Cprimary-id%3E)/primary_related/$ref');
+      expect(call[1].body).toBe('{"@odata.id":"contacts(<related-id>)"}');
+    });
+  });
+});

--- a/driver/test/repositories/currentUserRecordRepository.spec.ts
+++ b/driver/test/repositories/currentUserRecordRepository.spec.ts
@@ -1,12 +1,12 @@
-import { RecordRepository } from '../../src/repositories/index';
+import { CurrentUserRecordRepository, RecordRepository } from '../../src/repositories/index';
 import { AssociateRequest } from '../../src/requests';
 
-describe('RecordRepository', () => {
+describe('CurrentUserRecordRepository', () => {
   let xrmWebApi: jasmine.SpyObj<Xrm.WebApiOnline>;
   let recordRepository: RecordRepository;
   beforeEach(() => {
-    xrmWebApi = jasmine.createSpyObj<Xrm.WebApiOnline>('XrmWebApi', ['createRecord', 'deleteRecord', 'execute', 'retrieveMultipleRecords', 'updateRecord']);
-    recordRepository = new RecordRepository(xrmWebApi);
+    xrmWebApi = jasmine.createSpyObj<Xrm.WebApiOnline>('XrmWebApi', ['createRecord', 'deleteRecord', 'execute', 'retrieveMultipleRecords', 'updateRecord', 'retrieveRecord']);
+    recordRepository = new CurrentUserRecordRepository(xrmWebApi);
   });
 
   describe('createRecord(entityLogicalName, record)', () => {
@@ -17,6 +17,47 @@ describe('RecordRepository', () => {
       const actualReference = await recordRepository.createRecord('account', { name: 'Test Account' });
 
       expect(actualReference).toBe(expectedReference);
+    });
+  });
+
+  describe('retrieveRecord(entityLogicalName, id, query)', () => {
+    it('returns the retrieved record', async () => {
+      const expectedRecord = {};
+      xrmWebApi.retrieveRecord.and.returnValue(Promise.resolve(expectedRecord) as never);
+
+      const actualRecord = await recordRepository.retrieveRecord('account', 'account-id');
+
+      expect(actualRecord).toBe(expectedRecord);
+    });
+
+    it('passes the expected arguments to retrieveRecords', async () => {
+      const logicalName = 'account';
+      const id = 'id';
+      const query = '?$select=accountid';
+
+      await recordRepository.retrieveRecord(logicalName, id, query);
+
+      expect(xrmWebApi.retrieveRecord).toHaveBeenCalledWith(logicalName, id, query);
+    });
+  });
+
+  describe('retrieveMultipleRecord(entityLogicalName, query)', () => {
+    it('returns the retrieved records', async () => {
+      const expectedResponse: Xrm.RetrieveMultipleResult = { entities: [], nextLink: '' };
+      xrmWebApi.retrieveMultipleRecords.and.returnValue(Promise.resolve(expectedResponse) as never);
+
+      const actualResposne = await recordRepository.retrieveMultipleRecords('account', '?');
+
+      expect(actualResposne).toBe(expectedResponse);
+    });
+
+    it('passes the expected arguments to retrieveMultipleRecords', async () => {
+      const logicalName = 'account';
+      const query = '?$select=accountid';
+
+      await recordRepository.retrieveMultipleRecords(logicalName, query);
+
+      expect(xrmWebApi.retrieveMultipleRecords).toHaveBeenCalledWith(logicalName, query);
     });
   });
 

--- a/driver/test/repositories/metadataRepository.spec.ts
+++ b/driver/test/repositories/metadataRepository.spec.ts
@@ -3,13 +3,14 @@ import { MetadataRepository } from '../../src/repositories';
 const fetchMock = require('fetch-mock/es5/client');
 
 describe('MetadataRepository', () => {
-  let xrmWebApi: jasmine.SpyObj<Xrm.WebApiOnline>;
   let metadataRepo: MetadataRepository;
 
   beforeEach(() => {
-    xrmWebApi = jasmine.createSpyObj<Xrm.WebApiOnline>('XrmWebApi', ['createRecord', 'deleteRecord', 'execute', 'retrieveMultipleRecords', 'updateRecord']);
-    metadataRepo = new MetadataRepository(xrmWebApi);
-    fetchMock.reset();
+    metadataRepo = new MetadataRepository();
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
   });
 
   describe('getEntitySetForEntity(logicalName)', () => {
@@ -53,7 +54,7 @@ describe('MetadataRepository', () => {
     it('returns relationship metadata for the provided relationship schema name', async () => {
       const result = {};
       const relationshipSchemaName = 'contact_accounts';
-      fetchMock.mock(/.*RelationshipDefinitions(SchemaName='relationshipSchemaName')/, { body: result, sendAsJson: true });
+      fetchMock.mock('*', { body: result, sendAsJson: true });
 
       expectAsync(metadataRepo.getRelationshipMetadata(relationshipSchemaName))
         .toBeResolvedTo(result as never);

--- a/driver/tsconfig.json
+++ b/driver/tsconfig.json
@@ -7,10 +7,10 @@
     "strict": true,
     "sourceMap": true,
     "outDir": "dist",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
   },
   "include": [
     "src",
-    "test"
-  ]
+    "test",
+  ],
 }

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -86,7 +86,6 @@ jobs:
           searchFolder: bindings\tests\Capgemini.PowerApps.SpecFlowBindings.UiTests
           rerunFailedTests: true
           rerunMaxAttempts: 2
-        continueOnError: true
         env:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID: $(Application User Tenant ID)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID: $(Application User Client ID)

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -88,6 +88,9 @@ jobs:
           rerunMaxAttempts: 2
         continueOnError: true
         env:
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID: $(Application User Tenant ID)
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID: $(Application User Client ID)
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTSECRET: $(Application User Client Secret)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)  


### PR DESCRIPTION
## Purpose
Fixes #4. Currently, it's only possible to setup test data as the user who is executing the test. This causes problems in a number of scenarios, including when the user executing the test doesn't have the privileges required to setup the necessary test data.

## Approach
An application user with sufficient permissions to impersonate other users can be configured in the configuration file using the `applicationUser` property. This is then used by a new binding, `Given '(.*)' has created '(.*)'`, which accepts a user alias in addition to the file name captured by the existing test data binding. The users being impersonated must be configured in the `users` array in the configuration file, but do not need to have the `password` property set. If an `applicationUser` is configured, then this user will also be used for test data clean-up at the end of the test.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
