### PR TITLE
feat: allow driversPath to be environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ browserOptions: # optional - will use default EasyRepro options if not set
   width: 1920
   height: 1080
   startMaximized: false
+  driversPath: ChromeWebDriver # optional - [Recommended when running tests from Azure DevOps Microsoft-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium?view=azure-devops#decide-how-you-will-deploy-and-test-your-app)
 applicationUser: # optional - populate if creating test data for users other than the current user
   tenantId: SPECFLOW_POWERAPPS_TENANTID optional # mandatory
   clientId: SPECFLOW_POWERAPPS_CLIENTID # mandatory
@@ -70,7 +71,7 @@ users: # mandatory
     alias: a salesperson # mandatory
 ```
 
-The URL, usernames, passwords, and application user details will be set from environment variable (if found). Otherwise, the value from the config file will be used. The browserOptions node supports anything in the EasyRepro `BrowserOptions` class.
+The URL, driversPath, usernames, passwords, and application user details will be set from environment variable (if found). Otherwise, the value from the config file will be used. The browserOptions node supports anything in the EasyRepro `BrowserOptions` class.
 
 ### Writing feature files
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -64,6 +64,8 @@
                         .Build()
                         .Deserialize<TestConfiguration>(File.ReadAllText(configPath));
 
+                    testConfig.BrowserOptions.DriversPath = ConfigHelper.GetEnvironmentVariableIfExists(testConfig.BrowserOptions.DriversPath);
+
                     if (testConfig.BrowserOptions.DriversPath == Path.Combine(Directory.GetCurrentDirectory()))
                     {
                         if (Directory.GetFiles(testConfig.BrowserOptions.DriversPath, "*driver.exe").Length == 0)

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -5,6 +5,7 @@ browserOptions:
   width: 1920
   height: 1080
   startMaximized: false
+  driversPath: ChromeWebDriver
 applicationUser:
   tenantId: POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID
   clientId: POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID


### PR DESCRIPTION
## Purpose
Resolves #49. As documented [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium?view=azure-devops#decide-how-you-will-deploy-and-test-your-app), Microsoft recommend that you use the Web Drivers that are preinstalled on Microsoft Hosted agents, this avoids a version mismatch between Chrome and ChromeDriver. Prior to this commit, there was no way to make use of these environment variables.

## Approach
The BrowserOptions for EasyRepro allows for a driversPath variable to be provided. This commit adds logic to allow for this to be an Environment Variable. So the environment variables stated in the Microsoft Docs can be supplied. To run the ui tests for this repo locally, where the driver .exe is outputted to bin, simply create an environment variable for 'ChromeWebDriver' with a value of '.\\'.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
