### PR TITLE
fix: related record creation not impersonated

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/WebClientExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/WebClientExtensions.cs
@@ -1,0 +1,207 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Extensions
+{
+    using System;
+    using System.Linq;
+    using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+    using Microsoft.Dynamics365.UIAutomation.Browser;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Extensions to the <see cref="WebClient"/> class.
+    /// </summary>
+    internal static class WebClientExtensions
+    {
+        /// <summary>
+        /// Temporary workaround until https://github.com/microsoft/EasyRepro/issues/1087 is resolved.
+        /// </summary>
+        /// <param name="webClient">The <see cref="WebClient"/>.</param>
+        /// <param name="subGridName">The name of the subgrid.</param>
+        /// <param name="name">The name of the command.</param>
+        /// <param name="subName">The name of the sub-command.</param>
+        /// <param name="subSecondName">The name of the second sub-command.</param>
+        /// <returns>The <see cref="BrowserCommandResult{TReturn}"/>.</returns>
+        internal static BrowserCommandResult<bool> ClickSubGridCommandV2(this WebClient webClient, string subGridName, string name, string subName = null, string subSecondName = null)
+        {
+            return webClient.Execute(GetOptions("Click SubGrid Command"), driver =>
+            {
+                var subGrid = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridContents].Replace("[NAME]", subGridName)));
+
+                if (subGrid.TryFindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridCommandBar].Replace("[NAME]", subGridName)), out var subGridCommandBar))
+                {
+                    var items = subGridCommandBar.FindElements(By.TagName("button"));
+                    if (items.Any(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        items.FirstOrDefault(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)).Click(true);
+                        driver.WaitForTransaction();
+                    }
+                    else
+                    {
+                        if (items.Any(x => x.GetAttribute("aria-label").Contains("More Commands", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            items.FirstOrDefault(x => x.GetAttribute("aria-label").Contains("More Commands", StringComparison.OrdinalIgnoreCase)).Click(true);
+                            driver.WaitForTransaction();
+
+                            var overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
+
+                            if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", name))))
+                            {
+                                overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", name))).Click(true);
+                                driver.WaitForTransaction();
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException($"No command with the name '{name}' exists inside of {subGridName} Commandbar.");
+                            }
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"No command with the name '{name}' exists inside of {subGridName} CommandBar.");
+                        }
+                    }
+
+                    if (subName != null)
+                    {
+                        var overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
+
+                        if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))))
+                        {
+                            overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subName))).Click(true);
+                            driver.WaitForTransaction();
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"No command with the name '{subName}' exists under the {name} command inside of {subGridName} Commandbar.");
+                        }
+
+                        if (subSecondName != null)
+                        {
+                            overflowContainer = driver.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowContainer]));
+
+                            if (overflowContainer.HasElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))))
+                            {
+                                overflowContainer.FindElement(By.XPath(AppElements.Xpath[AppReference.Entity.SubGridOverflowButton].Replace("[NAME]", subSecondName))).Click(true);
+                                driver.WaitForTransaction();
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException($"No command with the name '{subSecondName}' exists under the {subName} command inside of {name} on the {subGridName} SubGrid Commandbar.");
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unable to locate the Commandbar for the {subGrid} SubGrid.");
+                }
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Temporary workaround until https://github.com/microsoft/EasyRepro/issues/1087 is resolved.
+        /// </summary>
+        /// <param name="webClient">The <see cref="WebClient"/>.</param>
+        /// <param name="name">The name of the command.</param>
+        /// <param name="subname">The name of the sub-command.</param>
+        /// <param name="subSecondName">The name of the second sub-command.</param>
+        /// <param name="thinkTime">The think time.</param>
+        /// <returns>The <see cref="BrowserCommandResult{TReturn}"/>.</returns>
+        internal static BrowserCommandResult<bool> ClickCommandV2(this WebClient webClient, string name, string subname = null, string subSecondName = null, int thinkTime = Constants.DefaultThinkTime)
+        {
+            return webClient.Execute(GetOptions($"Click Command"), driver =>
+            {
+                var ribbon = driver.WaitUntilAvailable(
+                    By.XPath(AppElements.Xpath[AppReference.CommandBar.Container]),
+                    TimeSpan.FromSeconds(5));
+
+                if (ribbon == null)
+                {
+                    ribbon = driver.WaitUntilAvailable(
+                        By.XPath(AppElements.Xpath[AppReference.CommandBar.ContainerGrid]),
+                        TimeSpan.FromSeconds(5),
+                        "Unable to find the ribbon.");
+                }
+
+                var items = ribbon.FindElements(By.TagName("button"));
+
+                if (items.Any(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    items.FirstOrDefault(x => x.GetAttribute("aria-label").Equals(name, StringComparison.OrdinalIgnoreCase)).Click(true);
+                    driver.WaitForTransaction();
+                }
+                else
+                {
+                    if (items.Any(x => x.GetAttribute("aria-label").Contains("More Commands", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        items.FirstOrDefault(x => x.GetAttribute("aria-label").Contains("More Commands", StringComparison.OrdinalIgnoreCase)).Click(true);
+                        driver.WaitForTransaction();
+
+                        if (driver.HasElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Button].Replace("[NAME]", name))))
+                        {
+                            driver.FindElement(By.XPath(AppElements.Xpath[AppReference.CommandBar.Button].Replace("[NAME]", name))).Click(true);
+                            driver.WaitForTransaction();
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"No command with the name '{name}' exists inside of Commandbar.");
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"No command with the name '{name}' exists inside of Commandbar.");
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(subname))
+                {
+                    var submenu = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
+
+                    var subbutton = submenu.FindElements(By.TagName("button")).FirstOrDefault(x => x.Text == subname);
+
+                    if (subbutton != null)
+                    {
+                        subbutton.Click(true);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"No sub command with the name '{subname}' exists inside of Commandbar.");
+                    }
+
+                    if (!string.IsNullOrEmpty(subSecondName))
+                    {
+                        var subSecondmenu = driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.CommandBar.MoreCommandsMenu]));
+
+                        var subSecondbutton = subSecondmenu.FindElements(By.TagName("button")).FirstOrDefault(x => x.Text == subSecondName);
+
+                        if (subSecondbutton != null)
+                        {
+                            subSecondbutton.Click(true);
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"No sub command with the name '{subSecondName}' exists inside of Commandbar.");
+                        }
+                    }
+                }
+
+                driver.WaitForTransaction();
+
+                return true;
+            });
+        }
+
+        private static BrowserCommandOptions GetOptions(string commandName)
+        {
+            return new BrowserCommandOptions(
+                Constants.DefaultTraceSource,
+                commandName,
+                Constants.DefaultRetryAttempts,
+                Constants.DefaultRetryDelay,
+                null,
+                true,
+                typeof(NoSuchElementException),
+                typeof(StaleElementReferenceException));
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/WebClientExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/WebClientExtensions.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Extensions to the <see cref="WebClient"/> class.
     /// </summary>
-    internal static class WebClientExtensions
+    public static class WebClientExtensions
     {
         /// <summary>
         /// Temporary workaround until https://github.com/microsoft/EasyRepro/issues/1087 is resolved.
@@ -20,7 +20,7 @@
         /// <param name="subName">The name of the sub-command.</param>
         /// <param name="subSecondName">The name of the second sub-command.</param>
         /// <returns>The <see cref="BrowserCommandResult{TReturn}"/>.</returns>
-        internal static BrowserCommandResult<bool> ClickSubGridCommandV2(this WebClient webClient, string subGridName, string name, string subName = null, string subSecondName = null)
+        public static BrowserCommandResult<bool> ClickSubGridCommandV2(this WebClient webClient, string subGridName, string name, string subName = null, string subSecondName = null)
         {
             return webClient.Execute(GetOptions("Click SubGrid Command"), driver =>
             {
@@ -107,7 +107,7 @@
         /// <param name="subSecondName">The name of the second sub-command.</param>
         /// <param name="thinkTime">The think time.</param>
         /// <returns>The <see cref="BrowserCommandResult{TReturn}"/>.</returns>
-        internal static BrowserCommandResult<bool> ClickCommandV2(this WebClient webClient, string name, string subname = null, string subSecondName = null, int thinkTime = Constants.DefaultThinkTime)
+        public static BrowserCommandResult<bool> ClickCommandV2(this WebClient webClient, string name, string subname = null, string subSecondName = null, int thinkTime = Constants.DefaultThinkTime)
         {
             return webClient.Execute(GetOptions($"Click Command"), driver =>
             {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/CommandBarSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/CommandBarSteps.cs
@@ -1,5 +1,6 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Steps
 {
+    using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using FluentAssertions;
     using TechTalk.SpecFlow;
 
@@ -16,7 +17,9 @@
         [When("I select the '(.*)' command")]
         public static void WhenISelectTheCommand(string commandName)
         {
-            XrmApp.CommandBar.ClickCommand(commandName);
+            // TODO: Replace with commented out code when new EasyRepro version available.
+            // XrmApp.CommandBar.ClickCommand(commandName);
+            Client.ClickCommandV2(commandName);
         }
 
         /// <summary>
@@ -27,7 +30,9 @@
         [When("I select the '([^']+)' command under the '([^']+)' flyout")]
         public static void WhenISelectTheCommandUnderTheFlyout(string commandName, string flyoutName)
         {
-            XrmApp.CommandBar.ClickCommand(flyoutName, commandName);
+            // TODO: Replace with commented out code when new EasyRepro version available.
+            // XrmApp.CommandBar.ClickCommand(flyoutName, commandName);
+            Client.ClickCommandV2(flyoutName, commandName);
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySubGridSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySubGridSteps.cs
@@ -27,7 +27,10 @@
         {
             Driver.WaitUntilVisible(
                 By.CssSelector($"div#dataSetRoot_{subGridName} button[aria-label=\"{commandName}\"]"));
-            XrmApp.Entity.SubGrid.ClickCommand(subGridName, commandName);
+
+            // TODO: Replace with commented out code when new EasyRepro version available.
+            // XrmApp.Entity.SubGrid.ClickCommand(subGridName, commandName);
+            Client.ClickSubGridCommandV2(subGridName, commandName);
         }
 
         /// <summary>
@@ -235,7 +238,10 @@
         {
             Driver.WaitUntilVisible(By.CssSelector($"div#dataSetRoot_{subGridName} li[aria-label=\"{flyoutName}\"]"));
 
-            XrmApp.Entity.SubGrid.ClickCommand(subGridName, flyoutName);
+            // TODO: Replace with commented out code when new EasyRepro version available.
+            // XrmApp.Entity.SubGrid.ClickCommand(subGridName, flyoutName);
+            Client.ClickSubGridCommandV2(subGridName, flyoutName);
+
         }
 
         /// <summary>
@@ -290,7 +296,9 @@
         [When(@"I click the '([^']+)' command under the '([^']+)' flyout on the '([^']+)' subgrid")]
         public static void WhenIClickTheCommandUnderTheFlyoutOnTheSubgrid(string commandName, string flyoutName, string subGridName)
         {
-            XrmApp.Entity.SubGrid.ClickCommand(subGridName, flyoutName, commandName);
+            // TODO: Replace with commented out code when new EasyRepro version available.
+            // XrmApp.Entity.SubGrid.ClickCommand(subGridName, flyoutName, commandName);
+            Client.ClickSubGridCommandV2(subGridName, flyoutName, commandName);
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySubGridSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySubGridSteps.cs
@@ -241,7 +241,6 @@
             // TODO: Replace with commented out code when new EasyRepro version available.
             // XrmApp.Entity.SubGrid.ClickCommand(subGridName, flyoutName);
             Client.ClickSubGridCommandV2(subGridName, flyoutName);
-
         }
 
         /// <summary>

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/EasyReproSelectorFixHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/EasyReproSelectorFixHooks.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Xrm.Tooling.Connector;
+using System.IO;
+using System.Reflection;
+using TechTalk.SpecFlow;
+
+namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
+{
+    /// <summary>
+    /// Temporary hooks related to fixing broken EasyRepro selectors.
+    /// </summary>
+    [Binding]
+    public class EasyReproSelectorFixHooks : PowerAppsStepDefiner
+    {
+        [BeforeTestRun]
+        public static void FixQuickCreateMenuItemSelector()
+        {
+            AppElements.Xpath[AppReference.Navigation.QuickCreateMenuItems] = "//button[@role='menuitem']";
+        }
+
+        [BeforeTestRun]
+        public static void FixEntitySubGridOverflowButtonSelector()
+        {
+            AppElements.Xpath[AppReference.Entity.SubGridOverflowButton] = ".//button[contains(@aria-label, '[NAME]')]";
+        }
+
+        [BeforeTestRun]
+        public static void FixRelatedCommandBarButtonSelector()
+        {
+            AppElements.Xpath[AppReference.Related.CommandBarButton] = ".//button[contains(@aria-label, '[NAME]') and contains(@id,'SubGrid')]";
+        }
+    }
+}

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/RelatedGridSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/RelatedGridSteps.feature
@@ -19,12 +19,12 @@ Scenario: Click command in a related grid
 	When I open the related 'Activities' tab
 	And I click the 'Add Existing Activity' button on the related grid
 
-Scenario: Assert a button is visible on a flyout in a related grid
+Scenario: Assert a button is not visible on a flyout in a related grid
 	When I open the related 'Activities' tab
 	And I click the 'New Activity' button on the related grid
 	Then I should not see a 'Missing' button in the flyout on the related grid
 
-Scenario: Assert a button is not visible on a flyout in a related grid
+Scenario: Assert a button is visible on a flyout in a related grid
 	When I open the related 'Activities' tab
 	And I click the 'New Activity' button on the related grid
 	Then I should see a 'Task' button in the flyout on the related grid

--- a/driver/test/data/deepInsertService.spec.ts
+++ b/driver/test/data/deepInsertService.spec.ts
@@ -1,6 +1,38 @@
 import { DeepInsertService, Record } from '../../src/data';
 import { MetadataRepository, RecordRepository } from '../../src/repositories';
 
+function mockRecord(
+  metadataRepo: jasmine.SpyObj<MetadataRepository>,
+  recordRepo: jasmine.SpyObj<RecordRepository>,
+): Record {
+  metadataRepo.getLookupPropertyForCollectionProperty.and.resolveTo('customerid_account');
+  metadataRepo.getRelationshipMetadata.and.resolveTo({ RelationshipType: 'OneToManyRelationship' } as Xrm.Metadata.OneToNRelationshipMetadata);
+  recordRepo.upsertRecord
+    .and.returnValues(
+      Promise.resolve({ id: '<company-id>', entityType: 'account' }),
+      Promise.resolve({ id: '<contact-id>', entityType: 'contact' }),
+      Promise.resolve({ id: '<account-id>', entityType: 'account' }),
+      Promise.resolve({ id: '<opportunity-id>', entityType: 'opportunity' }),
+    );
+
+  return {
+    name: 'Sample Account',
+    opportunity_customer_accounts: [
+      {
+        name: 'Test Opportunity associated to Sample Account',
+      },
+    ],
+    primarycontactid: {
+      firstname: 'John',
+      lastname: 'Smith',
+      masterid: {
+        firstname: 'Jim',
+        lastname: 'Smith',
+      },
+    },
+  };
+}
+
 describe('DeepInsertService', () => {
   let recordRepo: jasmine.SpyObj<RecordRepository>;
   let metadataRepo: jasmine.SpyObj<MetadataRepository>;
@@ -26,33 +58,7 @@ describe('DeepInsertService', () => {
 
   describe('.deepInsert(logicalName, record)', () => {
     it('creates each object in the object graph', async () => {
-      metadataRepo.getLookupPropertyForCollectionProperty.and.resolveTo('customerid_account');
-      metadataRepo.getRelationshipMetadata.and.resolveTo({ RelationshipType: 'OneToManyRelationship' } as Xrm.Metadata.OneToNRelationshipMetadata);
-      recordRepo.upsertRecord
-        .and.returnValues(
-          Promise.resolve({ id: '<company-id>', entityType: 'account' }),
-          Promise.resolve({ id: '<contact-id>', entityType: 'contact' }),
-          Promise.resolve({ id: '<account-id>', entityType: 'account' }),
-          Promise.resolve({ id: '<opportunity-id>', entityType: 'opportunity' }),
-        );
-
-      const testRecord: Record = {
-        name: 'Sample Account',
-        opportunity_customer_accounts: [
-          {
-            name: 'Test Opportunity associated to Sample Account',
-          },
-        ],
-        primarycontactid:
-        {
-          firstname: 'John',
-          lastname: 'Smith',
-          masterid: {
-            firstname: 'Jim',
-            lastname: 'Smith',
-          },
-        },
-      };
+      const testRecord = mockRecord(metadataRepo, recordRepo);
 
       await deepInsertService.deepInsert('account', testRecord, {});
 
@@ -232,32 +238,11 @@ describe('DeepInsertService', () => {
 
     it('overrides the default repository with the one passed as an argument (if provided)', async () => {
       const newRecordRepo = jasmine.createSpyObj<RecordRepository>('RecordRepository', ['upsertRecord']);
-      metadataRepo.getLookupPropertyForCollectionProperty.and.resolveTo('customerid_account');
-      metadataRepo.getRelationshipMetadata.and.resolveTo({ RelationshipType: 'OneToManyRelationship' } as Xrm.Metadata.OneToNRelationshipMetadata);
-      newRecordRepo.upsertRecord
-        .and.returnValues(
-          Promise.resolve({ id: '<contact-id>', entityType: 'contact' }),
-          Promise.resolve({ id: '<account-id>', entityType: 'account' }),
-          Promise.resolve({ id: '<opportunity-id>', entityType: 'opportunity' }),
-        );
-
-      const testRecord: Record = {
-        name: 'Sample Account',
-        opportunity_customer_accounts: [
-          {
-            name: 'Test Opportunity associated to Sample Account',
-          },
-        ],
-        primarycontactid:
-        {
-          firstname: 'John',
-          lastname: 'Smith',
-        },
-      };
+      const testRecord = mockRecord(metadataRepo, newRecordRepo);
 
       await deepInsertService.deepInsert('account', testRecord, {}, newRecordRepo);
 
-      expect(newRecordRepo.upsertRecord.calls.count()).toBe(3);
+      expect(newRecordRepo.upsertRecord.calls.count()).toBe(4);
     });
   });
 });

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -47,7 +47,7 @@ jobs:
           projectVersion: '$(GitVersion.SemVer)'
           extraProperties: |
             sonar.javascript.lcov.reportPaths=driver/test_results/coverage/lcov/lcov.info
-            sonar.coverage.exclusions=**\*spec.ts, bindings/tests/**/*, bindings/src/Capgemini.PowerApps.SpecFlowBindings.MSBuild/**/*
+            sonar.coverage.exclusions=**\*spec.ts, bindings/tests/**/*, bindings/src/Capgemini.PowerApps.SpecFlowBindings.MSBuild/**/*, bindings\src\Capgemini.PowerApps.SpecFlowBindings\Extensions\WebClientExtensions.cs
             sonar.eslint.reportPaths=$(Build.SourcesDirectory)/driver/test_results/analysis/eslint.json
       - task: VSBuild@1
         displayName: Build solution


### PR DESCRIPTION
## Purpose
When using the `Given '(.*)' has created '(.*)' binding, the root record would be correctly created as the impersonated user. However, related records would continue to be created as the logged in user.

## Approach
Passes the overridden repository to the private methods that were continuing to use the default repository.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
