### PR TITLE
New open form given step

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/EntityExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/EntityExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+    using Microsoft.Dynamics365.UIAutomation.Browser;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -23,6 +24,32 @@
             var elements = driver.FindElements(By.CssSelector($"div[data-id={fieldName}]"));
 
             return elements.Count > 0;
+        }
+
+        /// <summary>
+        /// This is required as <see cref="Entity.GetFormName"/> throws a <see cref="WebDriverException"/> when trying to get a form selector on a quick create form.
+        /// </summary>
+        /// <param name="driver">The Selenium WebDriver.</param>
+        /// <returns>The current form name.</returns>
+        public static string GetFormName(IWebDriver driver)
+        {
+            driver = driver ?? throw new ArgumentNullException(nameof(driver));
+
+            if (driver.HasElement(By.XPath("//section[@data-id = 'quickCreateRoot']")))
+            {
+                return driver.FindElement(By.XPath("//h1[@data-id = 'quickHeaderTitle']")).Text;
+            }
+
+            driver.WaitUntilVisible(By.XPath(AppElements.Xpath[AppReference.Entity.FormSelector]));
+
+            string formName = driver.ExecuteScript("return Xrm.Page.ui.formContext.ui.formSelector.getCurrentItem().getLabel();").ToString();
+
+            if (string.IsNullOrEmpty(formName))
+            {
+                throw new NotFoundException("Unable to retrieve Form Name for this entity");
+            }
+
+            return formName;
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
@@ -38,6 +38,13 @@
         void OpenTestRecord(string recordAlias);
 
         /// <summary>
+        /// Open a test record.
+        /// </summary>
+        /// <param name="formName">The name of the form.</param>
+        /// <param name="entityName">The logical name of the entity.</param>
+        void OpenForm(string formName, string entityName);
+
+        /// <summary>
         /// Gets an entity reference to a previously created test record.
         /// </summary>
         /// <param name="recordAlias">The alias of the test record.</param>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySteps.cs
@@ -185,6 +185,7 @@
         public static void GivenIViewForm(string formName, string entityName)
         {
             TestDriver.OpenForm(formName, entityName);
+            Driver.WaitForTransaction();
         }
 
         /// <summary>
@@ -343,7 +344,7 @@
         [Then(@"I am presented with a '(.*)' form for the '(.*)' entity")]
         public static void ThenIAmPresentedWithANewFormForTheEntity(string formName, string entityName)
         {
-            XrmApp.Entity.GetFormName().Should().Be(formName);
+            EntityExtensions.GetFormName(Driver).Should().Be(formName);
             XrmApp.Entity.GetEntityName().Should().Be(entityName);
         }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/EntitySteps.cs
@@ -177,6 +177,17 @@
         }
 
         /// <summary>
+        /// Navigate to a Form.
+        /// </summary>
+        /// <param name="formName">The name of the form.</param>
+        /// <param name="entityName">The name of the entity.</param>
+        [Given(@"I am viewing the '(.*)' form for the '(.*)' entity")]
+        public static void GivenIViewForm(string formName, string entityName)
+        {
+            TestDriver.OpenForm(formName, entityName);
+        }
+
+        /// <summary>
         /// Select a lookup on the form.
         /// </summary>
         /// <param name="fieldName">The name of the lookup.</param>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -84,6 +84,12 @@
             this.ExecuteDriverFunctionAsync($"openTestRecord('{recordAlias}')");
         }
 
+        /// <inheritdoc cref="ITestDriver"/>
+        public void OpenForm(string formName, string entityName)
+        {
+            this.ExecuteDriverFunctionAsync($"openForm('{formName}', '{entityName}')");
+        }
+
         /// <inheritdoc/>
         public EntityReference GetTestRecordReference(string recordAlias)
         {

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
@@ -103,10 +103,6 @@ Scenario: Open a create form
 	Given I am viewing the 'Information' form for the 'contact' entity
 	Then I am presented with a 'Information' form for the 'contact' entity
 
-Scenario: Open a quick create form
-	Given I am viewing the 'Contact Quick Create' form for the 'contact' entity
-	Then I am presented with a 'Contact Quick Create' form for the 'contact' entity
-
 Scenario: Select a lookup
 	When I select 'sb_lookup' lookup
 

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
@@ -99,6 +99,14 @@ Scenario: Open a form
 	When I select 'Additional information' form
 	Then I am presented with a 'Additional information' form for the 'sb_mockrecord' entity
 
+Scenario: Open a create form
+	Given I am viewing the 'Information' form for the 'contact' entity
+	Then I am presented with a 'Information' form for the 'contact' entity
+
+Scenario: Open a quick create form
+	Given I am viewing the 'Contact Quick Create' form for the 'contact' entity
+	Then I am presented with a 'Contact Quick Create' form for the 'contact' entity
+
 Scenario: Select a lookup
 	When I select 'sb_lookup' lookup
 

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/QuickCreateSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/QuickCreateSteps.feature
@@ -22,6 +22,10 @@ Scenarios:
 		| sb_dateonly    | datetime       | 1/1/2021           |
 		| sb_currency    | currency       | £10.00             |
 
+Scenario: Open a quick create form
+	Given I am viewing the ' quick create form' form for the 'sb_secondarymockrecord' entity
+	Then I am presented with a 'Quick Create: Secondary Mock Record' form for the 'sb_secondarymockrecord' entity
+
 Scenario: Enter lookup on a quick create
 	Given I have created 'a record with an alias'
 	When I enter 'The referenced record' into the 'sb_parent' lookup field on the quick create

--- a/driver/src/driver.ts
+++ b/driver/src/driver.ts
@@ -80,8 +80,11 @@ export default class Driver {
 
   // eslint-disable-next-line class-methods-use-this
   public async openForm(formName:string, nameOfEntity:string)
-    :Promise<Xrm.Async.PromiseLike<Xrm.Navigation.OpenFormResult>> {
+    :Promise<Xrm.Async.PromiseLike<Xrm.Navigation.OpenFormResult | void>> {
     const formInfo = await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=formid&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`);
+    if (formInfo.entities[0] === undefined) {
+      throw new Error(`The specified form ('${formName}') for entity ('${nameOfEntity}') does not exist.`);
+    }
     const formId = formInfo.entities[0].formid;
     const formType = formInfo.entities[0].type;
     const formPromise = Xrm.Navigation.openForm({
@@ -91,7 +94,7 @@ export default class Driver {
     });
 
     if (formType === 7) {
-      return Promise.resolve(formPromise);
+      return Promise.resolve();
     }
     return formPromise;
   }

--- a/driver/src/driver.ts
+++ b/driver/src/driver.ts
@@ -81,17 +81,19 @@ export default class Driver {
   // eslint-disable-next-line class-methods-use-this
   public async openForm(formName:string, nameOfEntity:string)
     :Promise<Xrm.Async.PromiseLike<Xrm.Navigation.OpenFormResult>> {
-    return Xrm.Navigation.openForm({
+    const formInfo = await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=formid&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`);
+    const formId = formInfo.entities[0].formid;
+    const formType = formInfo.entities[0].type;
+    const formPromise = Xrm.Navigation.openForm({
       entityName: nameOfEntity,
-      formId: await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=formid&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`).then(
-        (result) => result.entities[0].formid
-        ,
-      ),
-      useQuickCreateForm: await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=type&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`).then(
-        (result) => result.entities[0].type === 7,
-      )
-      ,
+      formId,
+      useQuickCreateForm: formType === 7,
     });
+
+    if (formType === 7) {
+      return Promise.resolve(formPromise);
+    }
+    return formPromise;
   }
 
   /**

--- a/driver/src/driver.ts
+++ b/driver/src/driver.ts
@@ -78,6 +78,22 @@ export default class Driver {
     });
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  public async openForm(formName:string, nameOfEntity:string)
+    :Promise<Xrm.Async.PromiseLike<Xrm.Navigation.OpenFormResult>> {
+    return Xrm.Navigation.openForm({
+      entityName: nameOfEntity,
+      formId: await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=formid&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`).then(
+        (result) => result.entities[0].formid
+        ,
+      ),
+      useQuickCreateForm: await Xrm.WebApi.retrieveMultipleRecords('systemform', `?$select=type&$filter=name eq '${formName}' and objecttypecode eq '${nameOfEntity}'`).then(
+        (result) => result.entities[0].type === 7,
+      )
+      ,
+    });
+  }
+
   /**
      * Gets a reference to a test record.
      * @param alias The alias of the test record.


### PR DESCRIPTION
## Purpose
Added Given step for navigating to a New Record standard or quick create form.  

## Approach
Added new method to the driver.ts to query for and open a form based on a given entity name and form name. Referenced this method in the C# driver and added a binding and tests.

## TODOs
- [X] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [X] Build and tests successful
