### PR TITLE
Corrected selector for ThenICanSeeOnlyTheFollowingRecordsInTheLookup

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -102,9 +102,9 @@
             }
 
             new WebDriverWait(Driver, TimeSpan.FromSeconds(5))
-                .Until(d => d.FindElement(By.CssSelector("ul[aria-label=\"Lookup Search Results\"] li")));
+                .Until(d => d.FindElement(By.CssSelector("ul[aria-label=\"Lookup results\"] li")));
             var items = Driver
-                .FindElements(By.CssSelector("ul[aria-label=\"Lookup Search Results\"] li"))
+                .FindElements(By.CssSelector("ul[aria-label=\"Lookup results\"] li"))
                 .Select(e => e.Text.Split(new string[] { "\r\n" }, StringSplitOptions.None)[0]);
 
             items.Count().Should().Be(recordNames.Rows.Count, because: "the flyout should only contain the given records");


### PR DESCRIPTION
## Purpose
Fixes #84.

## Approach
Fixes the CSS selector used in this binding.

## TODOs
- [X] Automated test coverage for new code
- [X] Documentation updated (if required)
- [X] Build and tests successful
