### PR TITLE
feat: allow bypassing/streamlining of login using browser profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The aim of this project is to make Power Apps test automation easier, faster and
 
 ## Installation
 
-Follow the guidance in the **Installation and Setup** section in https://specflow.org/getting-started/. After installing the IDE integration and setting up your project, install the NuGet package.
+Follow the guidance in the **Installation and Setup** section in SpecFlow's [docs](https://specflow.org/getting-started/). After installing the IDE integration and setting up your project, install the NuGet package.
 
 ```shell
 PM> Install-Package Capgemini.PowerApps.SpecFlowBindings
@@ -40,7 +40,7 @@ Once the NuGet package is installed, follow the SpecFlow [documentation](https:/
 
 ### WebDrivers
 
-We do not have a dependency on any specific WebDrivers. You will need to ensure that the correct WebDrivers are available in your project based on the browser that you are targetting. For example - if your configuration file is targetting Chrome - you can install the Chrome WebDriver via NuGet - 
+We do not have a dependency on any specific WebDrivers. You will need to ensure that the correct WebDrivers are available in your project based on the browser that you are targetting. For example - if your configuration file is targetting Chrome - you can install the Chrome WebDriver via NuGet -
 
 ```shell
 PM> Install-Package Selenium.Chrome.WebDriver
@@ -54,7 +54,7 @@ Installing the NuGet package creates a _power-apps-bindings.yml_ file in your pr
 
 ```yaml
 url: SPECFLOW_POWERAPPS_URL # mandatory
-useProfiles: false # defaults to false if not provided
+useProfiles: false # optional - defaults to false if not set
 browserOptions: # optional - will use default EasyRepro options if not set
   browserType: Chrome
   headless: true
@@ -74,7 +74,8 @@ users: # mandatory
 
 The URL, driversPath, usernames, passwords, and application user details will be set from environment variable (if found). Otherwise, the value from the config file will be used. The browserOptions node supports anything in the EasyRepro `BrowserOptions` class.
 
-#### User Profiles
+#### User profiles
+
 Setting the `useProfiles` property to true causes the solution to create and use a unique [profile](https://support.google.com/chrome/answer/2364824?co=GENIE.Platform%3DDesktop&hl=en) for each user listed in the config file. This currently only works in Chrome & Firefox and attempting to use it with Edge or IE will cause an exception to be thrown. By using profiles test runs for the same user will not be required to re-authenticate, this saves time during test runs. [To take full advantage of this you will need to have the "Stay Signed In" prompt enabled.](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/keep-me-signed-in)
 
 ### Writing feature files
@@ -83,9 +84,9 @@ You can use the predefined step bindings to write your tests.
 
 ```gherkin
 Scenario: User can create a new account
-	Given I am logged in to the 'Sales Team Member' app as 'an admin'
-	When I open the 'Accounts' sub area of the 'Customers' group
-	Then I can see the 'New' command
+ Given I am logged in to the 'Sales Team Member' app as 'an admin'
+ When I open the 'Accounts' sub area of the 'Customers' group
+ Then I can see the 'New' command
 ```
 
 Alternatively, write your own step bindings (see below).
@@ -118,14 +119,16 @@ You can create test data by using the following _Given_ steps -
 ```gherkin
 Given I have created 'a record'
 ```
+
 or
+
 ```gherkin
 Given 'someone' has created 'a record with a difference'
 ```
 
 These bindings look for a corresponding JSON file in a _data_ folder in the root of your project. The file is resolved using a combination of the directory structure and the file name. For example, the bindings above could resolve the following files:
 
-```
+```shell
 └───data
     │   a record.json
     │
@@ -136,11 +139,11 @@ These bindings look for a corresponding JSON file in a _data_ folder in the root
 If you are using the binding which creates data as someone other than the current user, you will need the following configuration to be present:
 
 - a user with a matching alias in the `users` array that has the `username` set
-- an application user with sufficient privileges to impersonate the above user configured in the `applicationUser` property. 
+- an application user with sufficient privileges to impersonate the above user configured in the `applicationUser` property.
 
 Refer to the Microsoft documentation on creating an application user [here](https://docs.microsoft.com/en-us/power-platform/admin/create-users-assign-online-security-roles#create-an-application-user).
 
-#### Data file syntax 
+#### Data file syntax
 
 The JSON is similar to that expected by Web API when creating records via a [deep insert](https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/webapi/create-entity-web-api#create-related-entities-in-one-operation).
 
@@ -161,6 +164,7 @@ The JSON is similar to that expected by Web API when creating records via a [dee
   ]
 }
 ```
+
 The example above will create the following:
 
 - An account
@@ -196,7 +200,6 @@ We support [faker.js](https://github.com/marak/Faker.js) moustache template synt
 When using faker syntax, you must also annotate number or date fields using `@faker.number`, `@faker.date` or `@faker.dateonly` to ensure that the JSON is formatted correctly.
 
 You can also dynamically set lookups by alias using `<lookup>@alias.bind` (this is limited to aliased records in other files - not the current file).
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Installing the NuGet package creates a _power-apps-bindings.yml_ file in your pr
 
 ```yaml
 url: SPECFLOW_POWERAPPS_URL # mandatory
+useProfiles: false # defaults to false if not provided
 browserOptions: # optional - will use default EasyRepro options if not set
   browserType: Chrome
   headless: true
@@ -72,6 +73,9 @@ users: # mandatory
 ```
 
 The URL, driversPath, usernames, passwords, and application user details will be set from environment variable (if found). Otherwise, the value from the config file will be used. The browserOptions node supports anything in the EasyRepro `BrowserOptions` class.
+
+#### User Profiles
+Setting the `useProfiles` property to true causes the solution to create and use a unique [profile](https://support.google.com/chrome/answer/2364824?co=GENIE.Platform%3DDesktop&hl=en) for each user listed in the config file. This currently only works in Chrome & Firefox and attempting to use it with Edge or IE will cause an exception to be thrown. By using profiles test runs for the same user will not be required to re-authenticate, this saves time during test runs. [To take full advantage of this you will need to have the "Stay Signed In" prompt enabled.](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/keep-me-signed-in)
 
 ### Writing feature files
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -63,6 +63,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="SpecFlow" Version="3.5.14" />

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -5,7 +5,7 @@
     <Product>Capgemini.PowerApps.SpecFlowBindings</Product>
     <Description>A SpecFlow bindings library for Power Apps.</Description>
     <Copyright>Capgemini Copyright © 2020</Copyright>
-    <Version>0.1.0</Version>
+    <Version>9.9.9</Version>
     <PackageIcon>icon.png</PackageIcon>
     <Authors>Capgemini_UK, ewingjm</Authors>
     <PackageId>Capgemini.PowerApps.SpecFlowBindings</PackageId>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Capgemini.PowerApps.SpecFlowBindings.csproj
@@ -5,7 +5,7 @@
     <Product>Capgemini.PowerApps.SpecFlowBindings</Product>
     <Description>A SpecFlow bindings library for Power Apps.</Description>
     <Copyright>Capgemini Copyright © 2020</Copyright>
-    <Version>9.9.9</Version>
+    <Version>0.1.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <Authors>Capgemini_UK, ewingjm</Authors>
     <PackageId>Capgemini.PowerApps.SpecFlowBindings</PackageId>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -1,5 +1,6 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
 {
+    using System.IO;
     using Microsoft.Dynamics365.UIAutomation.Browser;
     using OpenQA.Selenium.Chrome;
     using OpenQA.Selenium.Firefox;
@@ -32,7 +33,7 @@
             var options = base.ToFireFox();
             if (!string.IsNullOrEmpty(this.ProfileDirectory))
             {
-                this.ProfileDirectory = $"{this.ProfileDirectory}\\firefox";
+                this.ProfileDirectory = this.ProfileDirectory.EndsWith("firefox") ? this.ProfileDirectory : Path.Combine(this.ProfileDirectory, "firefox");
                 options.AddArgument($"-profile \"{this.ProfileDirectory}\"");
             }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -2,6 +2,7 @@
 {
     using Microsoft.Dynamics365.UIAutomation.Browser;
     using OpenQA.Selenium.Chrome;
+    using OpenQA.Selenium.Firefox;
 
     /// <summary>
     /// Extends the EasyRepro <see cref="BrowserOptions"/> class with additonal support for chrome profiles.
@@ -11,15 +12,28 @@
         /// <summary>
         /// Gets or sets the directory to use as the user profile.
         /// </summary>
-        public string ChromeProfileDirectory { get; set; }
+        public string ProfileDirectory { get; set; }
 
         /// <inheritdoc/>
         public override ChromeOptions ToChrome()
         {
             var options = base.ToChrome();
-            if (!string.IsNullOrEmpty(this.ChromeProfileDirectory))
+            if (!string.IsNullOrEmpty(this.ProfileDirectory))
             {
-                options.AddArgument($"--user-data-dir={this.ChromeProfileDirectory}");
+                options.AddArgument($"--user-data-dir={this.ProfileDirectory}");
+            }
+
+            return options;
+        }
+
+        /// <inheritdoc/>
+        public override FirefoxOptions ToFireFox()
+        {
+            var options = base.ToFireFox();
+            if (!string.IsNullOrEmpty(this.ProfileDirectory))
+            {
+                this.ProfileDirectory = $"{this.ProfileDirectory}\\firefox";
+                options.AddArgument($"-profile \"{this.ProfileDirectory}\"");
             }
 
             return options;

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -1,0 +1,28 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
+{
+    using Microsoft.Dynamics365.UIAutomation.Browser;
+    using OpenQA.Selenium.Chrome;
+
+    /// <summary>
+    /// Extends the EasyRepro <see cref="BrowserOptions"/> class with additonal support for chrome profiles.
+    /// </summary>
+    public class BrowserOptionsWithProfileSupport : BrowserOptions
+    {
+        /// <summary>
+        /// Gets or sets the directory to use as the user profile.
+        /// </summary>
+        public string ChromeProfileDirectory { get; set; }
+
+        /// <inheritdoc/>
+        public override ChromeOptions ToChrome()
+        {
+            var options = base.ToChrome();
+            if (!string.IsNullOrEmpty(this.ChromeProfileDirectory))
+            {
+                options.AddArgument($"--user-data-dir={this.ChromeProfileDirectory}");
+            }
+
+            return options;
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -1,5 +1,6 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
 {
+    using System;
     using System.IO;
     using Microsoft.Dynamics365.UIAutomation.Browser;
     using OpenQA.Selenium.Chrome;
@@ -8,7 +9,7 @@
     /// <summary>
     /// Extends the EasyRepro <see cref="BrowserOptions"/> class with additonal support for chrome profiles.
     /// </summary>
-    public class BrowserOptionsWithProfileSupport : BrowserOptions
+    public class BrowserOptionsWithProfileSupport : BrowserOptions, ICloneable
     {
         /// <summary>
         /// Gets or sets the directory to use as the user profile.
@@ -16,9 +17,16 @@
         public string ProfileDirectory { get; set; }
 
         /// <inheritdoc/>
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
+        /// <inheritdoc/>
         public override ChromeOptions ToChrome()
         {
             var options = base.ToChrome();
+
             if (!string.IsNullOrEmpty(this.ProfileDirectory))
             {
                 options.AddArgument($"--user-data-dir={this.ProfileDirectory}");
@@ -31,6 +39,7 @@
         public override FirefoxOptions ToFireFox()
         {
             var options = base.ToFireFox();
+
             if (!string.IsNullOrEmpty(this.ProfileDirectory))
             {
                 this.ProfileDirectory = this.ProfileDirectory.EndsWith("firefox") ? this.ProfileDirectory : Path.Combine(this.ProfileDirectory, "firefox");

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ConfigHelper.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/ConfigHelper.cs
@@ -14,6 +14,11 @@
         /// <returns>The environment variable value (if found) or the passed in value.</returns>
         public static string GetEnvironmentVariableIfExists(string value)
         {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
             var environmentVariableValue = Environment.GetEnvironmentVariable(value);
 
             if (!string.IsNullOrEmpty(environmentVariableValue))

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -39,6 +39,12 @@
         public bool UseProfiles { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets the base path where the user profiles are stored.
+        /// </summary>
+        [YamlMember(Alias = "profilesBasePath")]
+        public string ProfilesBasePath { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the browser options to use for running tests.
         /// </summary>
         [YamlMember(Alias = "browserOptions")]
@@ -68,17 +74,23 @@
         /// <summary>
         /// Retrieves the configuration for a user.
         /// </summary>
-        /// <param name="userAlias">The alias of the user.</param>
+        /// <param name="userAliasOrUsername">The alias or username of the user.</param>
         /// <returns>The user configuration.</returns>
-        public UserConfiguration GetUser(string userAlias)
+        public UserConfiguration GetUser(string userAliasOrUsername)
         {
             try
             {
-                return this.Users.First(u => u.Alias == userAlias);
+                UserConfiguration user = this.Users.FirstOrDefault(u => u.Alias == userAliasOrUsername);
+                if (user != null)
+                {
+                    return user;
+                }
+
+                return this.Users.First(u => u.Username == userAliasOrUsername);
             }
             catch (Exception ex)
             {
-                throw new ConfigurationErrorsException($"{GetUserException} User: {userAlias}", ex);
+                throw new ConfigurationErrorsException($"{GetUserException} User: {userAliasOrUsername}", ex);
             }
         }
     }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Configuration;
     using System.Linq;
-    using Microsoft.Dynamics365.UIAutomation.Browser;
     using YamlDotNet.Serialization;
 
     /// <summary>
@@ -32,6 +31,12 @@
         /// </summary>
         [YamlMember(Alias = "url")]
         public string Url { private get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use profiles.
+        /// </summary>
+        [YamlMember(Alias = "useProfiles")]
+        public bool UseProfiles { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the browser options to use for running tests.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -24,7 +24,7 @@
         /// </summary>
         public TestConfiguration()
         {
-            this.BrowserOptions = new BrowserOptions();
+            this.BrowserOptions = new BrowserOptionsWithProfileSupport();
         }
 
         /// <summary>
@@ -37,7 +37,7 @@
         /// Gets or sets the browser options to use for running tests.
         /// </summary>
         [YamlMember(Alias = "browserOptions")]
-        public BrowserOptions BrowserOptions { get; set; }
+        public BrowserOptionsWithProfileSupport BrowserOptions { get; set; }
 
         /// <summary>
         /// Gets or sets users that tests can be run as.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -17,7 +17,7 @@
         public const string FileName = "power-apps-bindings.yml";
 
         private const string GetUserException = "Unable to retrieve user configuration. Please ensure a user with the given alias exists in the config.";
-
+        private string profilesBasePath;
         /// <summary>
         /// Initializes a new instance of the <see cref="TestConfiguration"/> class.
         /// </summary>
@@ -42,7 +42,7 @@
         /// Gets or sets the base path where the user profiles are stored.
         /// </summary>
         [YamlMember(Alias = "profilesBasePath")]
-        public string ProfilesBasePath { get; set; } = null;
+        public string ProfilesBasePath { get => ConfigHelper.GetEnvironmentVariableIfExists(this.profilesBasePath); set => this.profilesBasePath = value; }
 
         /// <summary>
         /// Gets or sets the browser options to use for running tests.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -17,7 +17,9 @@
         public const string FileName = "power-apps-bindings.yml";
 
         private const string GetUserException = "Unable to retrieve user configuration. Please ensure a user with the given alias exists in the config.";
+
         private string profilesBasePath;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestConfiguration"/> class.
         /// </summary>
@@ -74,23 +76,17 @@
         /// <summary>
         /// Retrieves the configuration for a user.
         /// </summary>
-        /// <param name="userAliasOrUsername">The alias or username of the user.</param>
+        /// <param name="userAlias">The alias of the user.</param>
         /// <returns>The user configuration.</returns>
-        public UserConfiguration GetUser(string userAliasOrUsername)
+        public UserConfiguration GetUser(string userAlias)
         {
             try
             {
-                UserConfiguration user = this.Users.FirstOrDefault(u => u.Alias == userAliasOrUsername);
-                if (user != null)
-                {
-                    return user;
-                }
-
-                return this.Users.First(u => u.Username == userAliasOrUsername);
+                return this.Users.First(u => u.Alias == userAlias);
             }
             catch (Exception ex)
             {
-                throw new ConfigurationErrorsException($"{GetUserException} User: {userAliasOrUsername}", ex);
+                throw new ConfigurationErrorsException($"{GetUserException} User: {userAlias}", ex);
             }
         }
     }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/BrowserTypeExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/BrowserTypeExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Extensions
+{
+    using Microsoft.Dynamics365.UIAutomation.Browser;
+
+    /// <summary>
+    /// Provides extension methods on <see cref="BrowserType"/>.
+    /// </summary>
+    public static class BrowserTypeExtensions
+    {
+        /// <summary>
+        /// Determines if the given browser type supports profiles.
+        /// </summary>
+        /// <param name="type">The <see cref="BrowserType"/> to check.</param>
+        /// <returns>true if the browser supports profiles otherwise false.</returns>
+        public static bool SupportsProfiles(this BrowserType type)
+        {
+            switch (type)
+            {
+                case BrowserType.IE:
+                    return false;
+                case BrowserType.Chrome:
+                    return true;
+                case BrowserType.Firefox:
+                    return true;
+                case BrowserType.Edge:
+                    return false;
+                case BrowserType.Remote:
+                    return false;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/DirectoryInfoExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/DirectoryInfoExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Extensions
+{
+    using System.IO;
+
+    /// <summary>
+    /// Extensions to the <see cref="DirectoryInfo"/> class.
+    /// </summary>
+    public static class DirectoryInfoExtensions
+    {
+        /// <summary>
+        /// Copies the directory recursively to the target directory.
+        /// </summary>
+        /// <param name="source">The source directory.</param>
+        /// <param name="target">The target directory.</param>
+        public static void CopyTo(this DirectoryInfo source, DirectoryInfo target)
+        {
+            Directory.CreateDirectory(target.FullName);
+
+            foreach (var fileInfo in source.GetFiles())
+            {
+                fileInfo.CopyTo(Path.Combine(target.FullName, fileInfo.Name), true);
+            }
+
+            foreach (var subdirectory in source.GetDirectories())
+            {
+                subdirectory.CopyTo(target.CreateSubdirectory(subdirectory.Name));
+            }
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -1,8 +1,9 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Hooks
 {
+    using Capgemini.PowerApps.SpecFlowBindings.Extensions;
+    using OpenQA.Selenium;
     using System.IO;
     using System.Reflection;
-    using OpenQA.Selenium;
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -62,6 +63,19 @@
                 Client.Browser.TakeWindowScreenShot(
                     Path.Combine(screenshotsFolder, $"{fileName}.jpg"),
                     ScreenshotImageFormat.Jpeg);
+            }
+        }
+
+        /// <summary>
+        /// Deletes the user profiles used for this scenario.
+        /// </summary>
+        [AfterScenario(Order = 2)]
+        public void CleanUpProfileDirectory()
+        {
+            if (this.scenarioContext.ContainsKey("scenarioProfileDir"))
+            {
+                var scenarioProfileDir = this.scenarioContext["scenarioProfileDir"] as string;
+                new DirectoryInfo(scenarioProfileDir).Delete(true);
             }
         }
     }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -1,12 +1,9 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Hooks
 {
-    using Capgemini.PowerApps.SpecFlowBindings.Configuration;
-    using Microsoft.Dynamics365.UIAutomation.Browser;
-    using OpenQA.Selenium;
-    using Polly;
     using System;
     using System.IO;
     using System.Reflection;
+    using OpenQA.Selenium;
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -68,40 +65,6 @@
                     Path.Combine(screenshotsFolder, $"{fileName}.jpg"),
                     ScreenshotImageFormat.Jpeg);
             }
-        }
-
-        /// <summary>
-        /// Deletes the user profiles used for this scenario.
-        /// </summary>
-        [AfterScenario(Order = 0)]
-        public void CleanUpProfileDirectory()
-        {
-            Client.Browser.BrowserDisposing += new EventHandler<EventArgs>(this.TryCleanupProfile);
-        }
-
-        private void TryCleanupProfile(object sender, EventArgs e)
-        {
-            BrowserOptionsWithProfileSupport options = (sender as InteractiveBrowser).Options as BrowserOptionsWithProfileSupport;
-            var retryPolicy = Policy
-                .Handle<UnauthorizedAccessException>()
-                .Or<IOException>()
-                .WaitAndRetry(new[]
-                {
-                        3.Seconds(),
-                        5.Seconds(),
-                        10.Seconds(),
-                        15.Seconds(),
-                });
-            var fallbackPolicy = Policy
-                .Handle<UnauthorizedAccessException>()
-                .Or<IOException>()
-                .Fallback(() =>
-                {
-                    // Give up trying to delete the profile folder.
-                    Console.WriteLine("Failed to clean up user data dir as the browser has not exited after 33 seconds.");
-                });
-            var retryWithFallback = fallbackPolicy.Wrap(retryPolicy);
-            retryWithFallback.Execute(() => new DirectoryInfo(options.ProfileDirectory).Delete(true));
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -55,6 +55,7 @@
             {
                 var rootFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 var screenshotsFolder = Path.Combine(rootFolder, "screenshots");
+                Console.WriteLine(screenshotsFolder);
 
                 if (!Directory.Exists(screenshotsFolder))
                 {
@@ -85,6 +86,7 @@
                         3.Seconds(),
                         5.Seconds(),
                         10.Seconds(),
+                        15.Seconds(),
                     });
                 retryPolicy.Execute(() => new DirectoryInfo(scenarioProfileDir).Delete(true));
             }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/BeforeRunHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/BeforeRunHooks.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Capgemini.PowerApps.SpecFlowBindings.Configuration;
+    using Capgemini.PowerApps.SpecFlowBindings.Steps;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
     using Microsoft.Dynamics365.UIAutomation.Browser;
     using TechTalk.SpecFlow;
@@ -35,10 +36,11 @@
                 var userBrowserOptions = (BrowserOptionsWithProfileSupport)TestConfig.BrowserOptions.Clone();
                 userBrowserOptions.ProfileDirectory = baseDirectory;
 
-                using (var app = new XrmApp(new WebClient(userBrowserOptions)))
+                var webClient = new WebClient(userBrowserOptions);
+                using (new XrmApp(webClient))
                 {
                     var user = TestConfig.Users.First(u => u.Username == username);
-                    app.OnlineLogin.Login(TestConfig.GetTestUrl(), user.Username.ToSecureString(), user.Password.ToSecureString());
+                    LoginSteps.Login(webClient.Browser.Driver, TestConfig.GetTestUrl(), user.Username, user.Password);
                 }
             });
         }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/BeforeRunHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/BeforeRunHooks.cs
@@ -1,0 +1,42 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Hooks
+{
+    using System.IO;
+    using Capgemini.PowerApps.SpecFlowBindings.Configuration;
+    using Capgemini.PowerApps.SpecFlowBindings.Steps;
+    using TechTalk.SpecFlow;
+
+    /// <summary>
+    /// Hooks that run before the start of each run.
+    /// </summary>
+    [Binding]
+    public class BeforeRunHooks : PowerAppsStepDefiner
+    {
+        /// <summary>
+        /// Creates a new folder for the scenario and copies the session/cookies information from previous runs
+        /// </summary>
+        [BeforeTestRun]
+        public static void BaseProfileSetup()
+        {
+            if (!TestConfig.UseProfiles)
+            {
+                return;
+            }
+
+            foreach (var username in UserProfileDirectories.Keys)
+            {
+                var profileDirectory = UserProfileDirectories[username];
+                if (Directory.GetDirectories(profileDirectory).Length == 0)
+                {
+                    var baseDirectory = Path.Combine(profileDirectory, "base");
+                    Directory.CreateDirectory(baseDirectory);
+
+                    TestConfig.BrowserOptions.ProfileDirectory = baseDirectory;
+
+                    UserConfiguration user = TestConfig.GetUser(username);
+                    LoginSteps.Login(Driver, TestConfig.GetTestUrl(), user.Username, user.Password);
+                    Quit();
+                }
+            }
+        }
+    }
+}

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -215,7 +215,12 @@
             xrmApp = null;
             client = null;
             testDriver = null;
-            currentProfileDirectory = null;
+
+            if (!string.IsNullOrEmpty(currentProfileDirectory) && !Directory.Exists(currentProfileDirectory))
+            {
+                Directory.Delete(currentProfileDirectory, true);
+                currentProfileDirectory = null;
+            }
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -216,7 +216,7 @@
             client = null;
             testDriver = null;
 
-            if (!string.IsNullOrEmpty(currentProfileDirectory) && !Directory.Exists(currentProfileDirectory))
+            if (!string.IsNullOrEmpty(currentProfileDirectory) && Directory.Exists(currentProfileDirectory))
             {
                 Directory.Delete(currentProfileDirectory, true);
                 currentProfileDirectory = null;

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -185,8 +185,8 @@
         private static void GenerateUserProfiles(List<UserConfiguration> users)
         {
             userProfileDirectories = new Dictionary<string, string>();
-            string chromeProfileDir = $"{Directory.GetCurrentDirectory()}\\profiles";
-            CreateDirectoryIfNotExists(chromeProfileDir);
+            string profilesDir = $"{Directory.GetCurrentDirectory()}\\profiles";
+            CreateDirectoryIfNotExists(profilesDir);
 
             foreach (var user in users)
             {
@@ -195,10 +195,10 @@
                     continue;
                 }
 
-                var userChromeProfileDir = $"{chromeProfileDir}\\{user.Username}";
-                CreateDirectoryIfNotExists(userChromeProfileDir);
+                var userProfileDir = $"{profilesDir}\\{user.Username}";
+                CreateDirectoryIfNotExists(userProfileDir);
 
-                userProfileDirectories.Add(user.Username, userChromeProfileDir);
+                userProfileDirectories.Add(user.Username, userProfileDir);
             }
         }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -39,6 +39,7 @@
         private static XrmApp xrmApp;
 
         private static IDictionary<string, string> userProfilesDirectories;
+        private static object userProfilesDirectoriesLock = new object();
 
         /// <summary>
         /// Gets access token used to authenticate as the application user configured for testing.
@@ -176,14 +177,9 @@
                     throw new NotSupportedException($"The {testConfig.BrowserOptions.BrowserType} does not support profiles.");
                 }
 
-                if (userProfilesDirectories == null)
+                lock (userProfilesDirectoriesLock)
                 {
-                    userProfilesDirectories = new Dictionary<string, string>();
-                }
-
-                lock (userProfilesDirectories)
-                {
-                    if (userProfilesDirectories.Any())
+                    if (userProfilesDirectories != null)
                     {
                         return userProfilesDirectories;
                     }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -208,25 +208,22 @@
         /// </summary>
         protected static void Quit()
         {
-            if (xrmApp == null)
-            {
-                return;
-            }
-
-            xrmApp.Dispose();
+            xrmApp?.Dispose();
             xrmApp = null;
             client = null;
             testDriver = null;
 
             if (!string.IsNullOrEmpty(currentProfileDirectory) && Directory.Exists(currentProfileDirectory))
             {
+                var directoryToDelete = currentProfileDirectory;
+                currentProfileDirectory = null;
+
                 Policy
                     .Handle<UnauthorizedAccessException>()
-                    .WaitAndRetry(5, retry => (retry * 5).Seconds())
-                    .Execute(() =>
+                    .WaitAndRetry(3, retry => (retry * 5).Seconds())
+                    .ExecuteAndCapture(() =>
                     {
-                        Directory.Delete(currentProfileDirectory, true);
-                        currentProfileDirectory = null;
+                        Directory.Delete(directoryToDelete, true);
                     });
             }
         }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -208,7 +208,13 @@
         /// </summary>
         protected static void Quit()
         {
+            var driver = client?.Browser?.Driver;
+
             xrmApp?.Dispose();
+
+            // Ensuring that the driver gets disposed. Previously we were left with orphan processes and were unable to clean up profile folders.
+            driver?.Dispose();
+
             xrmApp = null;
             client = null;
             testDriver = null;
@@ -218,6 +224,7 @@
                 var directoryToDelete = currentProfileDirectory;
                 currentProfileDirectory = null;
 
+                // CrashpadMetrics-active.pma file can continue to be locked even after quitting Chrome. Requires retries.
                 Policy
                     .Handle<UnauthorizedAccessException>()
                     .WaitAndRetry(3, retry => (retry * 5).Seconds())

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Configuration;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using Capgemini.PowerApps.SpecFlowBindings.Configuration;
     using Capgemini.PowerApps.SpecFlowBindings.Extensions;
@@ -138,20 +139,22 @@
                 }
 
                 var directoriesDictionary = new Dictionary<string, string>();
-                string profilesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "profiles");
+
+                var basePath = string.IsNullOrEmpty(TestConfig.ProfilesBasePath) ? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) : TestConfig.ProfilesBasePath;
+                string profilesDir = Path.Combine(basePath, "profiles");
                 Directory.CreateDirectory(profilesDir);
 
-                foreach (var user in TestConfig.Users)
+                foreach (var username in TestConfig.Users.Select(u => u.Username).ToList())
                 {
-                    if (directoriesDictionary.ContainsKey(user.Username))
+                    if (directoriesDictionary.ContainsKey(username))
                     {
                         continue;
                     }
 
-                    var userProfileDir = Path.Combine(profilesDir, user.Username);
+                    var userProfileDir = Path.Combine(profilesDir, username);
                     Directory.CreateDirectory(userProfileDir);
 
-                    directoriesDictionary.Add(user.Username, userProfileDir);
+                    directoriesDictionary.Add(username, userProfileDir);
                 }
 
                 userProfileDirectories = directoriesDictionary;

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -34,7 +34,7 @@
         [ThreadStatic]
         private static XrmApp xrmApp;
 
-        private static Dictionary<string, string> userChromeProfileDirectories;
+        private static Dictionary<string, string> userProfileDirectories;
 
         /// <summary>
         /// Gets access token used to authenticate as the application user configured for testing.
@@ -78,7 +78,7 @@
                         }
                     }
 
-                    if (testConfig.BrowserOptions.BrowserType.SupportsProfiles())
+                    if (testConfig.UseProfiles && testConfig.BrowserOptions.BrowserType.SupportsProfiles())
                     {
                         GenerateChromeProfiles(testConfig.Users);
                     }
@@ -128,13 +128,13 @@
         /// <summary>
         /// Gets the directories for the chrome profiles if the brower type is chrome.
         /// </summary>
-        protected static Dictionary<string, string> UserChromeProfileDirectories
+        protected static Dictionary<string, string> UserProfileDirectories
         {
             get
             {
                 if (testConfig.BrowserOptions.BrowserType.SupportsProfiles())
                 {
-                    return userChromeProfileDirectories;
+                    return userProfileDirectories;
                 }
 
                 throw new ArgumentException($"The {testConfig.BrowserOptions.BrowserType} does not support profiles.");
@@ -184,13 +184,13 @@
         /// <param name="users">List of user to create profile directories for.</param>
         private static void GenerateChromeProfiles(List<UserConfiguration> users)
         {
-            userChromeProfileDirectories = new Dictionary<string, string>();
+            userProfileDirectories = new Dictionary<string, string>();
             string chromeProfileDir = $"{Directory.GetCurrentDirectory()}\\profiles";
             CreateDirectoryIfNotExists(chromeProfileDir);
 
             foreach (var user in users)
             {
-                if (userChromeProfileDirectories.ContainsKey(user.Username))
+                if (userProfileDirectories.ContainsKey(user.Username))
                 {
                     continue;
                 }
@@ -198,7 +198,7 @@
                 var userChromeProfileDir = $"{chromeProfileDir}\\{user.Username}";
                 CreateDirectoryIfNotExists(userChromeProfileDir);
 
-                userChromeProfileDirectories.Add(user.Username, userChromeProfileDir);
+                userProfileDirectories.Add(user.Username, userChromeProfileDir);
             }
         }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -80,7 +80,7 @@
 
                     if (testConfig.UseProfiles && testConfig.BrowserOptions.BrowserType.SupportsProfiles())
                     {
-                        GenerateChromeProfiles(testConfig.Users);
+                        GenerateUserProfiles(testConfig.Users);
                     }
                 }
 
@@ -182,7 +182,7 @@
         /// Creates a directory for each user to store information specific to a chrome profile.
         /// </summary>
         /// <param name="users">List of user to create profile directories for.</param>
-        private static void GenerateChromeProfiles(List<UserConfiguration> users)
+        private static void GenerateUserProfiles(List<UserConfiguration> users)
         {
             userProfileDirectories = new Dictionary<string, string>();
             string chromeProfileDir = $"{Directory.GetCurrentDirectory()}\\profiles";

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -139,7 +139,8 @@
 
                 if (string.IsNullOrEmpty(currentProfileDirectory))
                 {
-                    currentProfileDirectory = Path.Combine(Path.GetTempPath(), $"username-{Guid.NewGuid()}");
+                    var basePath = string.IsNullOrEmpty(TestConfig.ProfilesBasePath) ? Path.GetTempPath() : TestConfig.ProfilesBasePath;
+                    currentProfileDirectory = Path.Combine(basePath, "profiles", Guid.NewGuid().ToString());
                 }
 
                 return currentProfileDirectory;
@@ -175,14 +176,19 @@
                     throw new NotSupportedException($"The {testConfig.BrowserOptions.BrowserType} does not support profiles.");
                 }
 
+                if (userProfilesDirectories == null)
+                {
+                    userProfilesDirectories = new Dictionary<string, string>();
+                }
+
                 lock (userProfilesDirectories)
                 {
-                    if (userProfilesDirectories != null)
+                    if (userProfilesDirectories.Any())
                     {
                         return userProfilesDirectories;
                     }
 
-                    var basePath = string.IsNullOrEmpty(TestConfig.ProfilesBasePath) ? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) : TestConfig.ProfilesBasePath;
+                    var basePath = string.IsNullOrEmpty(TestConfig.ProfilesBasePath) ? Path.GetTempPath() : TestConfig.ProfilesBasePath;
                     var profilesDirectory = Path.Combine(basePath, "profiles");
 
                     Directory.CreateDirectory(profilesDirectory);
@@ -213,6 +219,7 @@
             xrmApp = null;
             client = null;
             testDriver = null;
+            currentProfileDirectory = null;
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -191,7 +191,11 @@
 
                     Directory.CreateDirectory(profilesDirectory);
 
-                    userProfilesDirectories = TestConfig.Users.Select(u => u.Username).Distinct().ToDictionary(u => u, u => Path.Combine(profilesDirectory, u));
+                    userProfilesDirectories = TestConfig.Users
+                        .Where(u => !string.IsNullOrEmpty(u.Password))
+                        .Select(u => u.Username)
+                        .Distinct()
+                        .ToDictionary(u => u, u => Path.Combine(profilesDirectory, u));
 
                     foreach (var dir in userProfilesDirectories.Values)
                     {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -6,6 +6,7 @@
     using System.IO;
     using System.Reflection;
     using Capgemini.PowerApps.SpecFlowBindings.Configuration;
+    using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
     using Microsoft.Identity.Client;
     using OpenQA.Selenium;
@@ -77,7 +78,7 @@
                         }
                     }
 
-                    if (testConfig.BrowserOptions.BrowserType == Microsoft.Dynamics365.UIAutomation.Browser.BrowserType.Chrome)
+                    if (testConfig.BrowserOptions.BrowserType.SupportsProfiles())
                     {
                         GenerateChromeProfiles(testConfig.Users);
                     }
@@ -131,12 +132,12 @@
         {
             get
             {
-                if (testConfig.BrowserOptions.BrowserType != Microsoft.Dynamics365.UIAutomation.Browser.BrowserType.Chrome)
+                if (testConfig.BrowserOptions.BrowserType.SupportsProfiles())
                 {
-                    throw new ArgumentException("Chrome profiles are only supported when using the Chrome browser.");
+                    return userChromeProfileDirectories;
                 }
 
-                return userChromeProfileDirectories;
+                throw new ArgumentException($"The {testConfig.BrowserOptions.BrowserType} does not support profiles.");
             }
         }
 
@@ -184,7 +185,7 @@
         private static void GenerateChromeProfiles(List<UserConfiguration> users)
         {
             userChromeProfileDirectories = new Dictionary<string, string>();
-            string chromeProfileDir = $"{Directory.GetCurrentDirectory()}\\chrome_profiles";
+            string chromeProfileDir = $"{Directory.GetCurrentDirectory()}\\profiles";
             CreateDirectoryIfNotExists(chromeProfileDir);
 
             foreach (var user in users)

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -137,13 +137,13 @@
                     return userProfileDirectories;
                 }
 
-                userProfileDirectories = new Dictionary<string, string>();
+                var directoriesDictionary = new Dictionary<string, string>();
                 string profilesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "profiles");
                 Directory.CreateDirectory(profilesDir);
 
                 foreach (var user in TestConfig.Users)
                 {
-                    if (userProfileDirectories.ContainsKey(user.Username))
+                    if (directoriesDictionary.ContainsKey(user.Username))
                     {
                         continue;
                     }
@@ -151,9 +151,10 @@
                     var userProfileDir = Path.Combine(profilesDir, user.Username);
                     Directory.CreateDirectory(userProfileDir);
 
-                    userProfileDirectories.Add(user.Username, userProfileDir);
+                    directoriesDictionary.Add(user.Username, userProfileDir);
                 }
 
+                userProfileDirectories = directoriesDictionary;
                 return userProfileDirectories;
             }
         }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -98,7 +98,7 @@
             return element != null;
         }
 
-        private void SetupScenarioProfile(string username)
+        private static void SetupScenarioProfile(string username)
         {
             var baseProfileDirectory = Path.Combine(UserProfileDirectories[username], "base");
             new DirectoryInfo(baseProfileDirectory).CopyTo(new DirectoryInfo(CurrentProfileDirectory));

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -60,7 +60,7 @@
 
             if (TestConfig.UseProfiles && TestConfig.BrowserOptions.BrowserType.SupportsProfiles())
             {
-                this.SetupScenarioProfile(user.Username);
+                SetupScenarioProfile(user.Username);
             }
 
             var url = TestConfig.GetTestUrl();

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -55,18 +55,15 @@
                 IWebElement usernameInput = driver.WaitUntilAvailable(By.XPath(Elements.Xpath[Reference.Login.UserId]), 30.Seconds());
                 usernameInput.SendKeys(username);
                 usernameInput.SendKeys(Keys.Enter);
-                driver.WaitForTransaction();
 
                 IWebElement passwordInput = driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Login.LoginPassword]), 30.Seconds());
                 passwordInput.SendKeys(password);
                 passwordInput.Submit();
-                driver.WaitForTransaction();
 
                 var staySignedIn = driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Login.StaySignedIn]), 10.Seconds());
                 if (staySignedIn != null)
                 {
                     staySignedIn.Click();
-                    driver.WaitForTransaction();
                 }
 
                 WaitForMainPage(driver, 30.Seconds());

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -23,9 +23,9 @@
         {
             var user = TestConfig.GetUser(userAlias);
 
-            if (TestConfig.BrowserOptions.BrowserType.SupportsProfiles())
+            if (TestConfig.UseProfiles && TestConfig.BrowserOptions.BrowserType.SupportsProfiles())
             {
-                TestConfig.BrowserOptions.ProfileDirectory = UserChromeProfileDirectories[user.Username];
+                TestConfig.BrowserOptions.ProfileDirectory = UserProfileDirectories[user.Username];
                 ForgetExistingAccounts(TestConfig.GetTestUrl());
             }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -30,10 +30,10 @@
             }
 
             XrmApp.OnlineLogin.Login(
-                    TestConfig.GetTestUrl(),
-                    user.Username.ToSecureString(),
-                    user.Password.ToSecureString(),
-                    string.Empty.ToSecureString());
+                TestConfig.GetTestUrl(),
+                user.Username.ToSecureString(),
+                user.Password.ToSecureString(),
+                string.Empty.ToSecureString());
 
             XrmApp.Navigation.OpenApp(appName);
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Threading;
     using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
     using Microsoft.Dynamics365.UIAutomation.Browser;
@@ -64,9 +63,13 @@
                 this.SetupScenarioProfile(user.Username);
             }
 
-            Login(Driver, TestConfig.GetTestUrl(), user.Username, user.Password);
+            var url = TestConfig.GetTestUrl();
+            Login(Driver, url, user.Username, user.Password);
 
-            XrmApp.Navigation.OpenApp(appName);
+            if (!url.Query.Contains("appid"))
+            {
+                XrmApp.Navigation.OpenApp(appName);
+            }
 
             CloseTeachingBubbles();
         }
@@ -98,11 +101,7 @@
         private void SetupScenarioProfile(string username)
         {
             var baseProfileDirectory = Path.Combine(UserProfileDirectories[username], "base");
-
-            lock (UserProfileDirectories[username])
-            {
-                new DirectoryInfo(baseProfileDirectory).CopyTo(new DirectoryInfo(CurrentProfileDirectory));
-            }
+            new DirectoryInfo(baseProfileDirectory).CopyTo(new DirectoryInfo(CurrentProfileDirectory));
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading;
     using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
     using Microsoft.Dynamics365.UIAutomation.Browser;
@@ -98,7 +99,10 @@
         {
             var baseProfileDirectory = Path.Combine(UserProfileDirectories[username], "base");
 
-            new DirectoryInfo(baseProfileDirectory).CopyTo(new DirectoryInfo(CurrentProfileDirectory));
+            lock (UserProfileDirectories[username])
+            {
+                new DirectoryInfo(baseProfileDirectory).CopyTo(new DirectoryInfo(CurrentProfileDirectory));
+            }
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading;
     using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using Microsoft.Dynamics365.UIAutomation.Api.UCI;
     using Microsoft.Dynamics365.UIAutomation.Browser;
@@ -14,6 +15,7 @@
     [Binding]
     public class LoginSteps : PowerAppsStepDefiner
     {
+        private static int currentScenarioId = 0;
         private ScenarioContext scenarioContext;
 
         /// <summary>
@@ -120,9 +122,14 @@
             }
         }
 
+        private static int GetScenarioId()
+        {
+            return Interlocked.Increment(ref currentScenarioId);
+        }
+
         private void SetupScenarioProfile(string username)
         {
-            Guid scenarioProfileId = Guid.NewGuid();
+            int scenarioProfileId = GetScenarioId();
             this.scenarioContext.Add("profileId", scenarioProfileId);
 
             var scenarioProfileDir = Path.Combine(UserProfileDirectories[username], scenarioProfileId.ToString());

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -20,6 +20,11 @@
         {
             var user = TestConfig.GetUser(userAlias);
 
+            if (TestConfig.BrowserOptions.BrowserType == BrowserType.Chrome)
+            {
+                TestConfig.BrowserOptions.ChromeProfileDirectory = UserChromeProfileDirectories[user.Username];
+            }
+
             XrmApp.OnlineLogin.Login(
                 TestConfig.GetTestUrl(),
                 user.Username.ToSecureString(),

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -130,9 +130,8 @@
         private void SetupScenarioProfile(string username)
         {
             int scenarioProfileId = GetScenarioId();
-            this.scenarioContext.Add("profileId", scenarioProfileId);
-
             var scenarioProfileDir = Path.Combine(UserProfileDirectories[username], scenarioProfileId.ToString());
+            this.scenarioContext.Add("scenarioProfileDir", scenarioProfileDir);
 
             var basePath = Path.Combine(UserProfileDirectories[username], "base");
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
@@ -1,4 +1,5 @@
 url: 
+useProfiles: false
 browserOptions: 
   browserType:
 users: 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
@@ -1,5 +1,6 @@
 url: 
 useProfiles: false
+profileBasePath: null
 browserOptions: 
   browserType:
 users: 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/content/power-apps-bindings.yml
@@ -1,6 +1,5 @@
 url: 
 useProfiles: false
-profileBasePath: null
 browserOptions: 
   browserType:
 users: 

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
@@ -47,8 +47,6 @@
                 $"RedirectUri=app://58145B91-0C36-4500-8554-080854F2AC97;" +
                 $"LoginPrompt=Auto";
 
-            Console.WriteLine(connectionString);
-
             return new CrmServiceClient(connectionString);
         }
     }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Xrm.Tooling.Connector;
-using System.IO;
-using System.Reflection;
-using TechTalk.SpecFlow;
-
-namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
 {
+    using Microsoft.Xrm.Tooling.Connector;
+    using System.IO;
+    using System.Reflection;
+    using TechTalk.SpecFlow;
+    using System;
+
     /// <summary>
     /// Hooks related to the mock solution used for testing.
     /// </summary>
@@ -36,6 +37,22 @@ namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
         private static CrmServiceClient GetServiceClient()
         {
             var admin = TestConfig.GetUser("an admin");
+            var url = TestConfig.GetTestUrl();
+
+            if (string.IsNullOrEmpty(admin.Username))
+            {
+                throw new ArgumentException("Username cannot be null or blank");
+            }
+
+            if (string.IsNullOrEmpty(admin.Password))
+            {
+                throw new ArgumentException("Password cannot be null or blank");
+            }
+
+            if (string.IsNullOrEmpty(url.AbsoluteUri))
+            {
+                throw new ArgumentException($"Url cannot be null or blank: {url}");
+            }
 
             return new CrmServiceClient(
                 $"AuthType=OAuth; " +

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
@@ -55,12 +55,12 @@
             }
 
             return new CrmServiceClient(
-                $"AuthType=OAuth; " +
-                $"Username={admin.Username}; " +
-                $"Password={admin.Password}; " +
-                $"Url={TestConfig.GetTestUrl()}; " +
-                $"AppId=51f81489-12ee-4a9e-aaae-a2591f45987d; " +
-                $"RedirectUri=app://58145B91-0C36-4500-8554-080854F2AC97; " +
+                $"AuthType=OAuth;" +
+                $"Username={admin.Username};" +
+                $"Password={admin.Password};" +
+                $"Url={TestConfig.GetTestUrl()};" +
+                $"AppId=51f81489-12ee-4a9e-aaae-a2591f45987d;" +
+                $"RedirectUri=app://58145B91-0C36-4500-8554-080854F2AC97;" +
                 $"LoginPrompt=Auto");
         }
     }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
@@ -1,10 +1,10 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
 {
     using Microsoft.Xrm.Tooling.Connector;
+    using System;
     using System.IO;
     using System.Reflection;
     using TechTalk.SpecFlow;
-    using System;
 
     /// <summary>
     /// Hooks related to the mock solution used for testing.
@@ -37,31 +37,19 @@
         private static CrmServiceClient GetServiceClient()
         {
             var admin = TestConfig.GetUser("an admin");
-            var url = TestConfig.GetTestUrl();
 
-            if (string.IsNullOrEmpty(admin.Username))
-            {
-                throw new ArgumentException("Username cannot be null or blank");
-            }
-
-            if (string.IsNullOrEmpty(admin.Password))
-            {
-                throw new ArgumentException("Password cannot be null or blank");
-            }
-
-            if (string.IsNullOrEmpty(url.AbsoluteUri))
-            {
-                throw new ArgumentException($"Url cannot be null or blank: {url}");
-            }
-
-            return new CrmServiceClient(
+            var connectionString = 
                 $"AuthType=OAuth;" +
                 $"Username={admin.Username};" +
                 $"Password={admin.Password};" +
                 $"Url={TestConfig.GetTestUrl()};" +
                 $"AppId=51f81489-12ee-4a9e-aaae-a2591f45987d;" +
                 $"RedirectUri=app://58145B91-0C36-4500-8554-080854F2AC97;" +
-                $"LoginPrompt=Auto");
+                $"LoginPrompt=Auto";
+
+            Console.WriteLine(connectionString);
+
+            return new CrmServiceClient(connectionString);
         }
     }
 }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/Hooks/MockSolutionHooks.cs
@@ -1,7 +1,6 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.UiTests.Hooks
 {
     using Microsoft.Xrm.Tooling.Connector;
-    using System;
     using System.IO;
     using System.Reflection;
     using TechTalk.SpecFlow;

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
@@ -24,6 +24,8 @@ Scenario: Switch view in a lookup
 	When I search for 'Some text' in the 'sb_lookup' lookup
 	And I switch to the 'Inactive Secondary Mock Records' view in the lookup
 
+# Selecting lookup entities in EasyRepro currently flaky.
+@ignore
 Scenario: Select a related entity in a lookup
 	When I search for '*' in the 'sb_customer' lookup
 	And I select the related 'Contacts' entity in the lookup

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -1,5 +1,6 @@
 url: POWERAPPS_SPECFLOW_BINDINGS_TEST_URL
 useProfiles: true
+profilesBasePath: POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH
 browserOptions:
   browserType: Chrome
   headless: true

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -1,4 +1,5 @@
 url: POWERAPPS_SPECFLOW_BINDINGS_TEST_URL
+useProfiles: true
 browserOptions:
   browserType: Chrome
   headless: true

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -1,5 +1,5 @@
 url: POWERAPPS_SPECFLOW_BINDINGS_TEST_URL
-useProfiles: false
+useProfiles: true
 profilesBasePath: POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH
 browserOptions:
   browserType: Chrome

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -1,5 +1,5 @@
 url: POWERAPPS_SPECFLOW_BINDINGS_TEST_URL
-useProfiles: true
+useProfiles: false
 profilesBasePath: POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH
 browserOptions:
   browserType: Chrome

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -1,6 +1,5 @@
 url: POWERAPPS_SPECFLOW_BINDINGS_TEST_URL
 useProfiles: true
-profilesBasePath: POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH
 browserOptions:
   browserType: Chrome
   headless: true

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -93,6 +93,7 @@ jobs:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
+          POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH: $(Build.SourcesDirectory)
       - task: SonarCloudAnalyze@1
         displayName: Analyse with SonarCloud
       - task: SonarCloudPublish@1

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -93,7 +93,6 @@ jobs:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
-          POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH: $(Agent.TempDirectory)
       - task: SonarCloudAnalyze@1
         displayName: Analyse with SonarCloud
       - task: SonarCloudPublish@1

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -92,7 +92,8 @@ jobs:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTSECRET: $(Application User Client Secret)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
-          POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)  
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
+          POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH: $(Agent.TempDirectory)
       - task: SonarCloudAnalyze@1
         displayName: Analyse with SonarCloud
       - task: SonarCloudPublish@1

--- a/templates/include-build-and-test-steps.yml
+++ b/templates/include-build-and-test-steps.yml
@@ -93,7 +93,6 @@ jobs:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
-          POWERAPPS_SPECFLOW_BINDINGS_PROFILE_BASE_PATH: $(Build.SourcesDirectory)
       - task: SonarCloudAnalyze@1
         displayName: Analyse with SonarCloud
       - task: SonarCloudPublish@1


### PR DESCRIPTION
## Purpose
Addresses #86 by using chrome/firefox user profiles to store history/cache enabling subsequent test cases to run faster.

## Approach
If the use of profiles is enabled via the yml config, it will create a profile directory for each of the defined users, this is then passed as an argument to the underlying driver.

There is currently an issue with EasyRepro with the "Pick an Account" Microsoft login dialog which means the Login functionality is currently broken. A helper method has been added to the Login steps to clear these from the dialog allowing the OOTB login functionality to be used. This can be removed when https://github.com/microsoft/EasyRepro/pull/1143 is merged.

