### PR TITLE
fix: users for alias not balanced across threads

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Configuration;
     using System.Linq;
+    using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using YamlDotNet.Serialization;
 
     /// <summary>
@@ -82,7 +83,7 @@
                             .Distinct()
                             .ToDictionary(
                                 alias => alias,
-                                alias => this.Users.Where(u => u.Alias == alias).GetEnumerator());
+                                alias => this.GetUserEnumerator(alias));
                     }
                 }
 
@@ -119,7 +120,7 @@
                     var aliasEnumerator = this.UserEnumerators[userAlias];
                     if (!aliasEnumerator.MoveNext())
                     {
-                        this.UserEnumerators[userAlias] = this.Users.Where(u => u.Alias == userAlias).GetEnumerator();
+                        this.UserEnumerators[userAlias] = this.GetUserEnumerator(userAlias);
                         aliasEnumerator = this.UserEnumerators[userAlias];
                         aliasEnumerator.MoveNext();
                     }
@@ -148,6 +149,11 @@
         internal void Flush()
         {
             CurrentUsers.Clear();
+        }
+
+        private IEnumerator<UserConfiguration> GetUserEnumerator(string alias)
+        {
+            return this.Users.Where(u => u.Alias == alias).ToList().Shuffle().GetEnumerator();
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/IListExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/IListExtensions.cs
@@ -1,0 +1,35 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extensions for <see cref="IList{T}"/>.
+    /// </summary>
+    internal static class IListExtensions
+    {
+        private static readonly Random Rand = new Random();
+
+        /// <summary>
+        /// Randomises the order of a list.
+        /// </summary>
+        /// <typeparam name="T">The type of list items.</typeparam>
+        /// <param name="list">The list.</param>
+        /// <returns>The shuffled list.</returns>
+        internal static IList<T> Shuffle<T>(this IList<T> list)
+        {
+            var n = list.Count;
+
+            while (n > 1)
+            {
+                n--;
+                var k = Rand.Next(n + 1);
+                T value = list[k];
+                list[k] = list[n];
+                list[n] = value;
+            }
+
+            return list;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

If tests are running with process or AppDomain isolation then all of the test threads will cycle individually through the users in the same order. This can lead to API limits be still being reached despite configuring many different users for an alias - this is due to the fact that tests are only load balanced within a thread rather than across threads.

## Approach

Shuffling the enumerators is an approximation that saves having to find a way to synchronise between AppDomains or processes.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
