### PR TITLE
Updated login steps to allow single sign on

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -35,8 +35,13 @@
                 usernameInput.SendKeys(Keys.Enter);
 
                 IWebElement passwordInput = driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Login.LoginPassword]), 30.Seconds());
-                passwordInput.SendKeys(password);
-                passwordInput.Submit();
+
+                // check to see if password is needed as it isn't needed in SSO scenario
+                if (passwordInput != null)
+                {
+                    passwordInput.SendKeys(password);
+                    passwordInput.Submit();
+                }
 
                 var staySignedIn = driver.WaitUntilClickable(By.XPath(Elements.Xpath[Reference.Login.StaySignedIn]), 10.Seconds());
                 if (staySignedIn != null)


### PR DESCRIPTION
## Purpose
When using the step "Given I am logged in to the '' app as ''" when single sign on is supported, the password tries to be put in but there is nowhere for it to be put in as no password is needed, so getting an error on object reference not set to an instance of an object. Closes #99 

## Approach
Checks to see if the password is required as part of the log in step.

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
