### PR TITLE
update record clean up retries to the collection

### DIFF
--- a/driver/test/data/dataManager.spec.ts
+++ b/driver/test/data/dataManager.spec.ts
@@ -113,7 +113,7 @@ describe('TestDriver', () => {
     it('retries failed delete requests', async () => {
       appUserRecordRepo.deleteRecord.and.throwError('Failed to delete');
 
-      dataManager.cleanup();
+      await dataManager.cleanup();
 
       expect(appUserRecordRepo.deleteRecord.calls.count()).toBe(6);
     });


### PR DESCRIPTION
## Purpose
Record clean up retries at a record level however some records might be prevented from deletion until related records are first deleted Closes #97 

## Approach
Retry  moved to the collection level rather than the record level which solves this issue

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
