### PR TITLE
ci: provision environments dynamically

### DIFF
--- a/azure-pipelines-pull-request.yml
+++ b/azure-pipelines-pull-request.yml
@@ -14,3 +14,5 @@ stages:
       environmentIdentifier: $(Build.BuildId)
       environmentDisplayName: SpecFlow Bindings - pr
       environmentDomainName: sfb-pr
+      buildUrl: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=$(Build.BuildId)
+      repositoryName: $(Build.Repository.Name)

--- a/azure-pipelines-pull-request.yml
+++ b/azure-pipelines-pull-request.yml
@@ -1,11 +1,16 @@
 name: $(GITVERSION_FullSemVer)
+
 trigger: none
+
 pr:
   - master
+
 pool:
   vmImage: 'windows-latest'
+
 stages:
-  - stage: BuildAndTest
-    displayName: Build and test
-    jobs:
-    - template: templates/include-build-and-test-steps.yml
+  - template: templates/build-and-test-stages.yml
+    parameters:
+      environmentIdentifier: $(Build.BuildId)
+      environmentDisplayName: SpecFlow Bindings - pr
+      environmentDomainName: sfb-pr

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,9 @@ stages:
       environmentIdentifier: $(Build.BuildId)
       environmentDisplayName: SpecFlow Bindings - CI
       environmentDomainName: sfb-ci
+      buildUrl: https://dev.azure.com/capgeminiuk/GitHub%20Support/_build/results?buildId=$(Build.BuildId)
+      repositoryName: $(Build.Repository.Name)
+      
   - stage: Publish
     displayName: Publish
     dependsOn: ManualValidation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,24 +1,24 @@
 name: $(GITVERSION_FullSemVer)
+
 trigger:
  batch: true
  branches:
   include:
     - master
+
 pr: none
+
 pool:
-  vmImage: 'windows-latest'
-variables:
-  solution: '**/*.sln'
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
-  GitVersion.SemVer: ''
+  vmImage: windows-latest
 stages:
-  - stage: BuildAndTest
-    displayName: Build and test
-    jobs:
-    - template: templates/include-build-and-test-steps.yml
+  - template: templates/build-and-test-stages.yml
+    parameters:
+      environmentIdentifier: $(Build.BuildId)
+      environmentDisplayName: SpecFlow Bindings - CI
+      environmentDomainName: sfb-ci
   - stage: Publish
     displayName: Publish
+    dependsOn: ManualValidation
     jobs:
       - job: PublishJob
         displayName: Publish 

--- a/templates/build-and-test-job.yml
+++ b/templates/build-and-test-job.yml
@@ -1,5 +1,21 @@
+parameters:
+  - name: environmentUrl
+    displayName: Environment URL
+    type: string
+  - name: environmentName
+    displayName: environmentName
+    type: string
+  - name: username
+    displayName: Username
+    type: string
+  - name: password
+    displayName: Password
+    type: string
+
 jobs: 
-  - job: BuildJob
+    # build and tests executed in single job in order to allow SonarCloud to capture coverage
+  - job: BuildAndTestJob
+    displayName: Build and Test
     variables:
       - name: GitVersion.SemVer
         value: ''
@@ -10,8 +26,6 @@ jobs:
         value: 'Any CPU'
       - name: buildConfiguration
         value: 'Release'
-    # build and tests executed in single job in order to allow SonarCloud to capture coverage
-    displayName: Build and Test
     timeoutInMinutes: 180 
     steps:
       - task: gitversion/setup@0
@@ -66,7 +80,7 @@ jobs:
       - task: PublishTestResults@2
         displayName: Publish unit test results
         inputs:
-          testResultsFiles: driver\test_results\reports\TESTS-*.xml
+          testResultsFiles: driver\test_results\reports\TESTS-*.xml        
       - task: PublishCodeCoverageResults@1
         displayName: Publish unit code coverage results
         inputs:
@@ -90,11 +104,11 @@ jobs:
           POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID: $(Application User Tenant ID)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID: $(Application User Client ID)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTSECRET: $(Application User Client Secret)
-          POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: $(User ADO Integration Username)
-          POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: $(User ADO Integration Password)
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME: ${{ parameters.username }}
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD: ${{ parameters.password }}
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_USERNAME2: $(Extra Admin User Username)
           POWERAPPS_SPECFLOW_BINDINGS_TEST_ADMIN_PASSWORD2: $(Extra Admin User Password)
-          POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: $(URL)
+          POWERAPPS_SPECFLOW_BINDINGS_TEST_URL: ${{ parameters.environmentUrl }}
       - task: SonarCloudAnalyze@1
         displayName: Analyse with SonarCloud
       - task: SonarCloudPublish@1

--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -86,7 +86,7 @@ stages:
             repositoryName: '$(RepositoryName)'
             comment: |
               **Manual validation requested**
-              Please perform any checks required on $(BuildTools.EnvironmentUrl) then approve @(BuildUrl).      
+              Please perform any checks required on $(BuildTools.EnvironmentUrl) then approve $(BuildUrl).      
       - job: ManualValidationJob
         displayName: Manual validation
         pool: server

--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -77,18 +77,21 @@ stages:
       BuildUrl: ${{ parameters.buildUrl }}
       BuildTools.EnvironmentUrl: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentUrl'] ]
     jobs:
+      - job: ManualValidationCommentJob
+        displayName: Manual validation (comment)
+        steps:
+        - task: GitHubComment@0
+          inputs:
+            gitHubConnection: 'github.com_tdashworth'
+            repositoryName: '$(RepositoryName)'
+            comment: |
+              **Manual validation requested**
+              Please perform any checks required on $(BuildTools.EnvironmentUrl) then approve @(BuildUrl).      
       - job: ManualValidationJob
         displayName: Manual validation
         pool: server
         timeoutInMinutes: 8640
         steps:
-          - task: GitHubComment@0
-            inputs:
-              gitHubConnection: 'github.com_tdashworth'
-              repositoryName: '$(RepositoryName)'
-              comment: |
-                **Manual validation requested**
-                Please perform any checks required on $(BuildTools.EnvironmentUrl) then approve @(BuildUrl).      
           - task: ManualValidation@0
             displayName: Wait for manual validation
             timeoutInMinutes: 7200

--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -1,0 +1,105 @@
+parameters:
+  - name: environmentIdentifier
+    displayName: Environment identifier
+    type: string
+  - name: environmentDisplayName
+    displayName: Environment display name
+    type: string
+  - name: environmentDomainName
+    displayName: Environment domain name
+    type: string
+
+stages:
+  - stage: ProvisionEnvironment
+    displayName: Provision environment
+    variables:
+      - name: Environment.Identifier
+        value: ${{ parameters.environmentIdentifier }}
+      - name: Environment.DisplayName
+        value: ${{ parameters.environmentDisplayName }} $(Environment.Identifier)
+      - name: TestEnvironment.DomainName
+        value: ${{ parameters.environmentDomainName }}-$(Environment.Identifier)
+      - group: Dataverse users
+    jobs:
+      - job: ProvisionEnvironmentJob
+        displayName: Provision environment
+        steps:
+          - task: PowerPlatformToolInstaller@0
+            displayName: Install Power Platform Build Tools
+            inputs:
+              DefaultVersion: true
+          - task: PowerPlatformCreateEnvironment@0
+            displayName: Create environment
+            inputs:
+              authenticationType: PowerPlatformSPN
+              PowerPlatformSPN: Dataverse (placeholder)
+              DisplayName: $(Environment.DisplayName)
+              EnvironmentSku: Sandbox
+              LocationName: unitedkingdom
+              LanguageName: 1033
+              CurrencyName: GBP
+              DomainName: $(TestEnvironment.DomainName)
+          - powershell: |
+              echo "##vso[task.setvariable variable=EnvironmentUrl;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTURL"
+              echo "##vso[task.setvariable variable=EnvironmentName;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTID"
+            displayName: Set output variables
+            name: SetEnvironmentOutputVariables  
+  - stage: BuildAndTest
+    displayName: Build and Test
+    dependsOn: ProvisionEnvironment
+    variables:
+      - name: BuildTools.EnvironmentUrl
+        value: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentUrl'] ]
+      - name: BuildTools.EnvironmentId
+        value: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentName'] ]
+      - group: Dataverse users
+    jobs:
+      - template: build-and-test-job.yml
+        parameters:
+          environmentUrl: $(BuildTools.EnvironmentUrl)
+          environmentName: $(BuildTools.EnvironmentId)
+          username: $(DataverseUsers.AzureDevOps.Username)
+          password: $(DataverseUsers.AzureDevOps.Password)
+  - stage: ManualValidation
+    displayName: Manual validation
+    dependsOn:
+      - ProvisionEnvironment
+      - BuildAndTest
+    condition: and(not(canceled()), ne(dependencies.ProvisionEnvironment.outputs['ProvisionEnvironmentJob.SetEnvironmentOutputVariables.EnvironmentUrl'], ''))
+    variables:
+      BuildTools.EnvironmentUrl: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentUrl'] ]
+    jobs:
+      - job: ManualValidationJob
+        displayName: Manual validation
+        pool: server
+        timeoutInMinutes: 8640
+        steps:
+          - task: ManualValidation@0
+            displayName: Wait for manual validation
+            timeoutInMinutes: 7200
+            inputs:
+              onTimeout: resume
+              instructions: Please perform any checks required on $(BuildTools.EnvironmentUrl).
+  - stage: DeleteEnvironment
+    displayName: Delete environment
+    dependsOn:
+      - ProvisionEnvironment
+      - ManualValidation
+    condition: ne(dependencies.ProvisionEnvironment.outputs['ProvisionEnvironmentJob.SetEnvironmentOutputVariables.EnvironmentUrl'], '')
+    variables:
+      BuildTools.EnvironmentUrl: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentUrl'] ]
+    jobs:
+      - job: DeleteEnvironmentJob
+        displayName: Delete environment
+        steps:
+          - checkout: none
+          - task: PowerPlatformToolInstaller@0
+            displayName: Install Power Platform Build Tools
+            inputs:
+              DefaultVersion: true
+          - task: PowerPlatformDeleteEnvironment@0
+            displayName: Delete environment
+            continueOnError: true
+            inputs:
+              authenticationType: PowerPlatformSPN
+              PowerPlatformSPN: Dataverse (placeholder)

--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -8,6 +8,12 @@ parameters:
   - name: environmentDomainName
     displayName: Environment domain name
     type: string
+  - name: buildUrl
+    displayName: Build URL
+    type: string
+  - name: repositoryName
+    displayName: Repository Name
+    type: string
 
 stages:
   - stage: ProvisionEnvironment
@@ -67,6 +73,8 @@ stages:
       - BuildAndTest
     condition: and(not(canceled()), ne(dependencies.ProvisionEnvironment.outputs['ProvisionEnvironmentJob.SetEnvironmentOutputVariables.EnvironmentUrl'], ''))
     variables:
+      RepositoryName: ${{ parameters.repositoryName }}
+      BuildUrl: ${{ parameters.buildUrl }}
       BuildTools.EnvironmentUrl: $[ stageDependencies.ProvisionEnvironment.ProvisionEnvironmentJob.outputs['SetEnvironmentOutputVariables.EnvironmentUrl'] ]
     jobs:
       - job: ManualValidationJob
@@ -74,6 +82,13 @@ stages:
         pool: server
         timeoutInMinutes: 8640
         steps:
+          - task: GitHubComment@0
+            inputs:
+              gitHubConnection: 'github.com_tdashworth'
+              repositoryName: '$(RepositoryName)'
+              comment: |
+                **Manual validation requested**
+                Please perform any checks required on $(BuildTools.EnvironmentUrl) then approve @(BuildUrl).      
           - task: ManualValidation@0
             displayName: Wait for manual validation
             timeoutInMinutes: 7200


### PR DESCRIPTION
## Purpose
Our ci/test environments have been disabled due to limited power platform storage. This impacts new code being tested for PR and the publishing of new package versions.

## Approach
A copy from [powerapps-packagedeployer-template](https://github.com/Capgemini/powerapps-packagedeployer-template/pull/75) which creates a new environment every time and then disposes of it after manual validation.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [ ] Build and tests successful
