### PR TITLE
fix: refresh app access token

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/ITestDriver.cs
@@ -21,6 +21,12 @@
         void LoadTestDataAsUser(string data, string username);
 
         /// <summary>
+        /// Updates the access token of the application user repository.
+        /// </summary>
+        /// <param name="accessToken">accessToken to refresh.</param>
+        void UpdateAccessToken(string accessToken);
+
+        /// <summary>
         /// Loads scenario test data.
         /// </summary>
         /// <param name="data">The data to load.</param>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -43,26 +43,26 @@
         private static IDictionary<string, string> userProfilesDirectories;
         private static object userProfilesDirectoriesLock = new object();
 
+        private static string accessToken;
+
         /// <summary>
-        /// Date and Time when access token will expire.
+        /// Date and Time when access token expires....
         /// </summary>
         private static DateTimeOffset accessTokenExpiresOn;
 
         /// <summary>
         /// Gets access token used to authenticate as the application user configured for testing.
         /// </summary>
-        protected static string NewAccessToken
+        protected static string AccessToken
         {
             get
             {
-                var hostSegments = TestConfig.GetTestUrl().Host.Split('.');
+                if (accessToken == null)
+                {
+                    accessToken = GetAccessToken();
+                }
 
-                var result = GetApp().AcquireTokenForClient(new string[] { $"https://{hostSegments[0]}.api.{hostSegments[1]}.dynamics.com//.default" })
-                    .ExecuteAsync()
-                    .Result;
-
-                accessTokenExpiresOn = result.ExpiresOn;
-                return result.AccessToken;
+                return accessToken;
             }
         }
 
@@ -165,16 +165,19 @@
         {
             get
             {
-                if (testDriver == null) // First Time
+                // First Time
+                if (testDriver == null)
                 {
                     testDriver = new TestDriver((IJavaScriptExecutor)Driver);
-                    testDriver.InjectOnPage(TestConfig.ApplicationUser != null ? NewAccessToken : null);
+                    testDriver.InjectOnPage(TestConfig.ApplicationUser != null ? AccessToken : null);
                 }
 
                 if (TestConfig.ApplicationUser != null && DateTime.UtcNow >= accessTokenExpiresOn)
                 {
                     // Set it in the JS
-                    testDriver.UpdateAccessToken(NewAccessToken);
+                    accessToken = GetAccessToken();
+                    testDriver.UpdateAccessToken(AccessToken);
+                    Console.WriteLine("Application user access token has been refreshed");
                 }
 
                 return testDriver;
@@ -219,6 +222,21 @@
 
                 return userProfilesDirectories;
             }
+        }
+
+        /// <summary>
+        /// Acquires an access token used to authenticate as the application user configured for testing.
+        /// </summary>
+        /// <returns>Returns access token as a string.</returns>
+        protected static string GetAccessToken()
+        {
+            var hostSegments = TestConfig.GetTestUrl().Host.Split('.');
+
+            var result = GetApp().AcquireTokenForClient(new string[] { $"https://{hostSegments[0]}.api.{hostSegments[1]}.dynamics.com//.default" })
+                .ExecuteAsync()
+                .Result;
+            accessTokenExpiresOn = result.ExpiresOn;
+            return result.AccessToken;
         }
 
         /// <summary>

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -60,6 +60,16 @@
             this.javascriptExecutor.ExecuteScript(scriptBuilder.ToString());
         }
 
+        void UpdateAccessToken(string accessToken)
+        {
+            var script = $"appUserRecordRepository.UpdateAccessToken({accessToken})";
+            this.javascriptExecutor.ExecuteScript(script);
+        }
+
+
+
+
+
         /// <inheritdoc cref="ITestDriver"/>
         public void LoadTestData(string data)
         {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/TestDriver.cs
@@ -46,8 +46,8 @@
             if (!string.IsNullOrEmpty(authToken))
             {
                 scriptBuilder.AppendLine(
-                    $@"var appUserRecordRepository = new {LibraryNamespace}.AuthenticatedRecordRepository(metadataRepository, '{authToken}');
-                       var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()], appUserRecordRepository);");
+                    $@"window.appUserRecordRepository = new {LibraryNamespace}.AuthenticatedRecordRepository(metadataRepository, '{authToken}');
+                       var dataManager = new {LibraryNamespace}.DataManager(recordRepository, deepInsertService, [new {LibraryNamespace}.FakerPreprocessor()], window.appUserRecordRepository);");
             }
             else
             {
@@ -60,15 +60,13 @@
             this.javascriptExecutor.ExecuteScript(scriptBuilder.ToString());
         }
 
-        void UpdateAccessToken(string accessToken)
+        /// <inheritdoc cref="ITestDriver"/>
+        public void UpdateAccessToken(string accessToken)
         {
-            var script = $"appUserRecordRepository.UpdateAccessToken({accessToken})";
+            var script = $"window.appUserRecordRepository.updateAccessToken('{accessToken}')";
+
             this.javascriptExecutor.ExecuteScript(script);
         }
-
-
-
-
 
         /// <inheritdoc cref="ITestDriver"/>
         public void LoadTestData(string data)

--- a/driver/src/repositories/authenticatedRecordRepository.ts
+++ b/driver/src/repositories/authenticatedRecordRepository.ts
@@ -24,13 +24,17 @@ export default class AuthenticatedRecordRepository implements RecordRepository {
     this.metadataRepo = metadataRepo;
 
     this.headers = {
-      Authorization: `Bearer ${authToken}`,
       'Content-Type': 'application/json',
     };
+    this.updateAccessToken(authToken);
 
     if (userToImpersonateId) {
       this.headers.CallerObjectId = userToImpersonateId;
     }
+  }
+
+  public updateAccessToken(authToken: string) {
+    this.headers['Authorization'] = `Bearer ${authToken}`;
   }
 
   /**

--- a/templates/build-and-test-job.yml
+++ b/templates/build-and-test-job.yml
@@ -16,8 +16,6 @@ jobs:
     # build and tests executed in single job in order to allow SonarCloud to capture coverage
   - job: BuildAndTestJob
     displayName: Build and Test
-    strategy:
-      parallel: 3
     variables:
       - name: GitVersion.SemVer
         value: ''


### PR DESCRIPTION
## Purpose
The authentication access token that is created expires if all the SpecFlow Bindings tests exceed one hour. 

## Approach
Changes have been made to allow the access token to be refreshed after it has expired. The following files have been changed:
  PowerAppsStepDefiner.cs
  TestDriver.cs
  ITestDriver.cs

Also modified build-and-test-job.yml to stop the jobs from running in parallel.

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
