### PR TITLE
feat: additional capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ browserOptions: # optional - will use default EasyRepro options if not set
   height: 1080
   startMaximized: false
   driversPath: ChromeWebDriver # optional - [Recommended when running tests from Azure DevOps Microsoft-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium?view=azure-devops#decide-how-you-will-deploy-and-test-your-app)
+  additionalCapabilities: # optional - additional capabilities to pass to the WebDriver
+    capabilityName: capabilityValue 
 applicationUser: # optional - populate if creating test data for users other than the current user
   tenantId: SPECFLOW_POWERAPPS_TENANTID optional # mandatory
   clientId: SPECFLOW_POWERAPPS_CLIENTID # mandatory

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -1,20 +1,39 @@
 ﻿namespace Capgemini.PowerApps.SpecFlowBindings.Configuration
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
+    using Capgemini.PowerApps.SpecFlowBindings.Extensions;
     using Microsoft.Dynamics365.UIAutomation.Browser;
+    using OpenQA.Selenium;
     using OpenQA.Selenium.Chrome;
+    using OpenQA.Selenium.Edge;
     using OpenQA.Selenium.Firefox;
+    using OpenQA.Selenium.IE;
 
     /// <summary>
-    /// Extends the EasyRepro <see cref="BrowserOptions"/> class with additonal support for chrome profiles.
+    /// Extends the EasyRepro <see cref="BrowserOptions"/> class with support for additional configuration.
     /// </summary>
     public class BrowserOptionsWithProfileSupport : BrowserOptions, ICloneable
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="BrowserOptionsWithProfileSupport"/> class.
+        /// </summary>
+        public BrowserOptionsWithProfileSupport()
+            : base()
+        {
+            this.AdditionalCapabilities = new Dictionary<string, object>();
+        }
+
+        /// <summary>
         /// Gets or sets the directory to use as the user profile.
         /// </summary>
         public string ProfileDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional capabilities.
+        /// </summary>
+        public Dictionary<string, object> AdditionalCapabilities { get; set; }
 
         /// <inheritdoc/>
         public object Clone()
@@ -32,6 +51,8 @@
                 options.AddArgument($"--user-data-dir={this.ProfileDirectory}");
             }
 
+            this.AddAdditionalCapabilities(options);
+
             return options;
         }
 
@@ -46,7 +67,37 @@
                 options.AddArgument($"-profile \"{this.ProfileDirectory}\"");
             }
 
+            this.AddAdditionalCapabilities(options);
+
             return options;
+        }
+
+        /// <inheritdoc/>
+        public override EdgeOptions ToEdge()
+        {
+            var options = base.ToEdge();
+
+            this.AddAdditionalCapabilities(options);
+
+            return options;
+        }
+
+        /// <inheritdoc/>
+        public override InternetExplorerOptions ToInternetExplorer()
+        {
+            var options = base.ToInternetExplorer();
+
+            this.AddAdditionalCapabilities(options);
+
+            return options;
+        }
+
+        private void AddAdditionalCapabilities(DriverOptions options)
+        {
+            foreach (var desiredCapability in this.AdditionalCapabilities)
+            {
+                options.AddGlobalCapability(desiredCapability.Key, desiredCapability.Value);
+            }
         }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/DriverOptionsExtensions.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Extensions/DriverOptionsExtensions.cs
@@ -1,0 +1,38 @@
+﻿namespace Capgemini.PowerApps.SpecFlowBindings.Extensions
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Chrome;
+    using OpenQA.Selenium.Firefox;
+    using OpenQA.Selenium.IE;
+
+    /// <summary>
+    /// Extensions to the <see cref="DriverOptions"/> class.
+    /// </summary>
+    public static class DriverOptionsExtensions
+    {
+        /// <summary>
+        /// Adds a global capability to driver options.
+        /// </summary>
+        /// <param name="options">The driver options.</param>
+        /// <param name="name">The name of the capability.</param>
+        /// <param name="value">The value of the capability.</param>
+        internal static void AddGlobalCapability(this DriverOptions options, string name, object value)
+        {
+            switch (options)
+            {
+                case ChromeOptions chromeOptions:
+                    chromeOptions.AddAdditionalCapability(name, value, true);
+                    break;
+                case FirefoxOptions firefoxOptions:
+                    firefoxOptions.AddAdditionalCapability(name, value, true);
+                    break;
+                case InternetExplorerOptions internetExplorerOptions:
+                    internetExplorerOptions.AddAdditionalCapability(name, value, true);
+                    break;
+                default:
+                    options.AddAdditionalCapability(name, value);
+                    break;
+            }
+        }
+    }
+}

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/power-apps-bindings.yml
@@ -7,6 +7,8 @@ browserOptions:
   height: 1080
   startMaximized: false
   driversPath: ChromeWebDriver
+  additionalCapabilities:
+    capabilityName: capabilityVaue
 applicationUser:
   tenantId: POWERAPPS_SPECFLOW_BINDINGS_TEST_TENANTID
   clientId: POWERAPPS_SPECFLOW_BINDINGS_TEST_CLIENTID


### PR DESCRIPTION
## Purpose
Allows additional capabilities to be passed to the `WebDriver`. This can be useful when running tests against a Selenium Grid.

## Approach
Adds an `AdditionalCapabilities` property to the `TestConfig`. Can be read from the config file or set in code.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
