### PR TITLE
feat: `I click to perform an advanced lookup on '(.*)' lookup` step

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -125,6 +125,10 @@
             Driver.WaitForTransaction();
         }
 
+        /// <summary>
+        /// Open the advanced lookup dialog for the given lookup field.
+        /// </summary>
+        /// <param name="lookupField">The name of the lookup.</param>
         [When(@"I click to perform an advanced lookup on '(.*)' lookup")]
         public void WhenIClickToPerformAnAdvancedLookup(string lookupField)
         {

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LookupSteps.cs
@@ -124,5 +124,11 @@
             Driver.WaitUntilAvailable(By.XPath(AppElements.Xpath[AppReference.Entity.LookupFieldExistingValue].Replace("[NAME]", lookupName))).Click();
             Driver.WaitForTransaction();
         }
+
+        [When(@"I click to perform an advanced lookup on '(.*)' lookup")]
+        public void WhenIClickToPerformAnAdvancedLookup(string lookupField)
+        {
+            Driver.ClickWhenAvailable(By.CssSelector("button[data-id=\"[NAME].fieldControl-LookupResultsDropdown_[NAME]_advancedLookupBtnContainer\"]".Replace("[NAME]", lookupField)));
+        }
     }
 }

--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/LookupSteps.feature
@@ -26,7 +26,7 @@ Scenario: Switch view in a lookup
 
 Scenario: Open advanced lookup
 	When I search for 'Some text' in the 'sb_lookup' lookup
-	And I click to perform an advanced lookup
+	And I click to perform an advanced lookup on 'sb_lookup' lookup
 
 @ignore # EasyRepro issue: https://github.com/microsoft/EasyRepro/issues/1311
 Scenario: Select a related entity in a lookup


### PR DESCRIPTION
## Purpose
Added a step to open the advanced lookup dialog for a lookup field. 

## Approach
Uses the driver and CSS selector to find the link to click. 

> Ideally this would be EasyRepro code. 

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
