### PR TITLE
Issue # 94 - Added a new binding and unit test to assert if the auto-…

### DIFF
--- a/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
+++ b/bindings/tests/Capgemini.PowerApps.SpecFlowBindings.UiTests/EntitySteps.feature
@@ -190,3 +190,9 @@ Scenario: Assert fields not editable
 	Then I can not edit the following fields
 		| Field             |
 		| createdonbehalfby |
+
+Scenario: Assert if the auto-number field contains value as per the input pattern/format
+	When I enter 'Some text' into the 'sb_name' text field on the form
+	And I save the record
+	Then I can see a value with the format 'SB-{SEQNUM:4}-{RANDSTRING:6}-{DATETIMEUTC:yyyyMMddhhmm}' in the 'sb_autonumberone' auto-number header field
+	And I can see a value with the format '{DATETIMEUTC:yyyyddMM}-{SEQNUM:4}' in the 'sb_autonumbertwo' auto-number field

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/AppModuleSiteMaps/sb_MockApp/AppModuleSiteMap.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/AppModuleSiteMaps/sb_MockApp/AppModuleSiteMap.xml
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <AppModuleSiteMap xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SiteMapUniqueName>sb_MockApp</SiteMapUniqueName>
+  <EnableCollapsibleGroups>False</EnableCollapsibleGroups>
+  <ShowHome>True</ShowHome>
+  <ShowPinned>True</ShowPinned>
+  <ShowRecents>True</ShowRecents>
   <SiteMap IntroducedVersion="7.0.0.0">
     <Area Id="area_primary" ResourceId="SitemapDesigner.NewArea" DescriptionResourceId="SitemapDesigner.NewArea" ShowGroups="true" IntroducedVersion="7.0.0.0">
       <Titles>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/AppModuleSiteMaps/sb_MockApp/AppModuleSiteMap_managed.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/AppModuleSiteMaps/sb_MockApp/AppModuleSiteMap_managed.xml
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <AppModuleSiteMap xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SiteMapUniqueName>sb_MockApp</SiteMapUniqueName>
+  <EnableCollapsibleGroups>False</EnableCollapsibleGroups>
+  <ShowHome>True</ShowHome>
+  <ShowPinned>True</ShowPinned>
+  <ShowRecents>True</ShowRecents>
   <SiteMap IntroducedVersion="7.0.0.0">
     <Area Id="area_primary" ResourceId="SitemapDesigner.NewArea" DescriptionResourceId="SitemapDesigner.NewArea" ShowGroups="true" IntroducedVersion="7.0.0.0">
       <Titles>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/Entity.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/Entity.xml
@@ -416,6 +416,7 @@
           <Name>owningbusinessunit</Name>
           <LogicalName>owningbusinessunit</LogicalName>
           <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
           <ImeMode>auto</ImeMode>
           <ValidForUpdateApi>0</ValidForUpdateApi>
           <ValidForReadApi>1</ValidForReadApi>
@@ -562,6 +563,86 @@
           </displaynames>
           <Descriptions>
             <Description description="Contains the id of the process associated with the entity." languagecode="1033" />
+          </Descriptions>
+        </attribute>
+        <attribute PhysicalName="sb_AutonumberOne">
+          <Type>nvarchar</Type>
+          <Name>sb_autonumberone</Name>
+          <LogicalName>sb_autonumberone</LogicalName>
+          <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ReadOnlyInUI|ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
+          <ImeMode>auto</ImeMode>
+          <ValidForUpdateApi>1</ValidForUpdateApi>
+          <ValidForReadApi>1</ValidForReadApi>
+          <ValidForCreateApi>1</ValidForCreateApi>
+          <IsCustomField>1</IsCustomField>
+          <IsAuditEnabled>1</IsAuditEnabled>
+          <IsSecured>0</IsSecured>
+          <IntroducedVersion>1.0.0.2</IntroducedVersion>
+          <IsCustomizable>1</IsCustomizable>
+          <IsRenameable>1</IsRenameable>
+          <CanModifySearchSettings>1</CanModifySearchSettings>
+          <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
+          <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
+          <SourceType>0</SourceType>
+          <IsGlobalFilterEnabled>0</IsGlobalFilterEnabled>
+          <IsSortableEnabled>0</IsSortableEnabled>
+          <CanModifyGlobalFilterSettings>1</CanModifyGlobalFilterSettings>
+          <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
+          <IsDataSourceSecret>0</IsDataSourceSecret>
+          <AutoNumberFormat>SB-{SEQNUM:4}-{RANDSTRING:6}-{DATETIMEUTC:yyyyMMddhhmm}</AutoNumberFormat>
+          <IsSearchable>0</IsSearchable>
+          <IsFilterable>0</IsFilterable>
+          <IsRetrievable>0</IsRetrievable>
+          <IsLocalizable>0</IsLocalizable>
+          <Format>text</Format>
+          <MaxLength>100</MaxLength>
+          <Length>200</Length>
+          <displaynames>
+            <displayname description="Auto-number 1" languagecode="1033" />
+          </displaynames>
+          <Descriptions>
+            <Description description="" languagecode="1033" />
+          </Descriptions>
+        </attribute>
+        <attribute PhysicalName="sb_AutonumberTwo">
+          <Type>nvarchar</Type>
+          <Name>sb_autonumbertwo</Name>
+          <LogicalName>sb_autonumbertwo</LogicalName>
+          <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ReadOnlyInUI|ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
+          <ImeMode>auto</ImeMode>
+          <ValidForUpdateApi>1</ValidForUpdateApi>
+          <ValidForReadApi>1</ValidForReadApi>
+          <ValidForCreateApi>1</ValidForCreateApi>
+          <IsCustomField>1</IsCustomField>
+          <IsAuditEnabled>1</IsAuditEnabled>
+          <IsSecured>0</IsSecured>
+          <IntroducedVersion>1.0.0.2</IntroducedVersion>
+          <IsCustomizable>1</IsCustomizable>
+          <IsRenameable>1</IsRenameable>
+          <CanModifySearchSettings>1</CanModifySearchSettings>
+          <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
+          <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
+          <SourceType>0</SourceType>
+          <IsGlobalFilterEnabled>0</IsGlobalFilterEnabled>
+          <IsSortableEnabled>0</IsSortableEnabled>
+          <CanModifyGlobalFilterSettings>1</CanModifyGlobalFilterSettings>
+          <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
+          <IsDataSourceSecret>0</IsDataSourceSecret>
+          <AutoNumberFormat>{DATETIMEUTC:yyyyddMM}-{SEQNUM:4}</AutoNumberFormat>
+          <IsSearchable>0</IsSearchable>
+          <IsFilterable>0</IsFilterable>
+          <IsRetrievable>0</IsRetrievable>
+          <IsLocalizable>0</IsLocalizable>
+          <Format>text</Format>
+          <MaxLength>100</MaxLength>
+          <Length>200</Length>
+          <displaynames>
+            <displayname description="Auto-number 2" languagecode="1033" />
+          </displaynames>
+          <Descriptions>
+            <Description description="" languagecode="1033" />
           </Descriptions>
         </attribute>
         <attribute PhysicalName="sb_Choice">
@@ -1910,6 +1991,7 @@
       <IsDocumentRecommendationsEnabled>0</IsDocumentRecommendationsEnabled>
       <IsBPFEntity>0</IsBPFEntity>
       <OwnershipTypeMask>UserOwned</OwnershipTypeMask>
+      <EntityMask>ActivityPointer</EntityMask>
       <IsAuditEnabled>0</IsAuditEnabled>
       <IsRetrieveAuditEnabled>0</IsRetrieveAuditEnabled>
       <IsRetrieveMultipleAuditEnabled>0</IsRetrieveMultipleAuditEnabled>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/FormXml/main/{974e0b5b-0d50-40fd-b607-61bb0812dda0}.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/FormXml/main/{974e0b5b-0d50-40fd-b607-61bb0812dda0}.xml
@@ -28,6 +28,14 @@
                       </cell>
                     </row>
                     <row>
+                      <cell id="{611d8d20-211c-8077-0330-3d381e17ee85}" showlabel="true" locklevel="0">
+                        <labels>
+                          <label description="Auto-number 2" languagecode="1033" />
+                        </labels>
+                        <control id="sb_autonumbertwo" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="sb_autonumbertwo" disabled="false" />
+                      </cell>
+                    </row>
+                    <row>
                       <cell id="{ee7e9058-7950-4797-b682-01eeee93f0ab}" locklevel="0">
                         <labels>
                           <label description="Text" languagecode="1033" />
@@ -246,10 +254,11 @@
                 <label description="" languagecode="1033" />
               </labels>
             </cell>
-            <cell id="{6ba2785a-8c2c-4f55-9bce-977862b81864}" showlabel="false">
+            <cell id="{8d465b85-3ba5-758c-d3b0-6575e13ec6e7}" showlabel="true" locklevel="0">
               <labels>
-                <label description="" languagecode="1033" />
+                <label description="Auto-number 1" languagecode="1033" />
               </labels>
+              <control id="header_sb_autonumberone" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="sb_autonumberone" disabled="false" />
             </cell>
             <cell id="{10fc1664-f736-4dbd-a625-953d789d9146}" locklevel="0">
               <labels>
@@ -359,9 +368,6 @@
           </row>
         </rows>
       </footer>
-      <DisplayConditions Order="0" FallbackForm="true">
-        <Everyone />
-      </DisplayConditions>
       <formLibraries>
         <Library name="sb_/js/sb_mockrecord.form.js" libraryUniqueId="{14cfe9ba-3f37-439c-b6e6-28bebb4cc0ad}" />
       </formLibraries>
@@ -372,6 +378,39 @@
           </Handlers>
         </event>
       </events>
+      <Navigation>
+        <NavBar></NavBar>
+        <NavBarAreas>
+          <NavBarArea Id="Info">
+            <Titles>
+              <Title LCID="1033" Text="Common" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Sales">
+            <Titles>
+              <Title LCID="1033" Text="Sales" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Service">
+            <Titles>
+              <Title LCID="1033" Text="Service" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Marketing">
+            <Titles>
+              <Title LCID="1033" Text="Marketing" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="ProcessCenter">
+            <Titles>
+              <Title LCID="1033" Text="Process Sessions" />
+            </Titles>
+          </NavBarArea>
+        </NavBarAreas>
+      </Navigation>
+      <DisplayConditions Order="0" FallbackForm="true">
+        <Everyone />
+      </DisplayConditions>
     </form>
     <IsCustomizable>1</IsCustomizable>
     <CanBeDeleted>1</CanBeDeleted>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/FormXml/main/{974e0b5b-0d50-40fd-b607-61bb0812dda0}_managed.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_MockRecord/FormXml/main/{974e0b5b-0d50-40fd-b607-61bb0812dda0}_managed.xml
@@ -28,6 +28,14 @@
                       </cell>
                     </row>
                     <row>
+                      <cell id="{611d8d20-211c-8077-0330-3d381e17ee85}" showlabel="true" locklevel="0">
+                        <labels>
+                          <label description="Auto-number 2" languagecode="1033" />
+                        </labels>
+                        <control id="sb_autonumbertwo" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="sb_autonumbertwo" disabled="false" />
+                      </cell>
+                    </row>
+                    <row>
                       <cell id="{ee7e9058-7950-4797-b682-01eeee93f0ab}" locklevel="0">
                         <labels>
                           <label description="Text" languagecode="1033" />
@@ -246,10 +254,11 @@
                 <label description="" languagecode="1033" />
               </labels>
             </cell>
-            <cell id="{6ba2785a-8c2c-4f55-9bce-977862b81864}" showlabel="false">
+            <cell id="{8d465b85-3ba5-758c-d3b0-6575e13ec6e7}" showlabel="true" locklevel="0">
               <labels>
-                <label description="" languagecode="1033" />
+                <label description="Auto-number 1" languagecode="1033" />
               </labels>
+              <control id="header_sb_autonumberone" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="sb_autonumberone" disabled="false" />
             </cell>
             <cell id="{10fc1664-f736-4dbd-a625-953d789d9146}" locklevel="0">
               <labels>
@@ -359,9 +368,6 @@
           </row>
         </rows>
       </footer>
-      <DisplayConditions Order="0" FallbackForm="true">
-        <Everyone />
-      </DisplayConditions>
       <formLibraries>
         <Library name="sb_/js/sb_mockrecord.form.js" libraryUniqueId="{14cfe9ba-3f37-439c-b6e6-28bebb4cc0ad}" />
       </formLibraries>
@@ -372,6 +378,39 @@
           </Handlers>
         </event>
       </events>
+      <Navigation>
+        <NavBar></NavBar>
+        <NavBarAreas>
+          <NavBarArea Id="Info">
+            <Titles>
+              <Title LCID="1033" Text="Common" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Sales">
+            <Titles>
+              <Title LCID="1033" Text="Sales" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Service">
+            <Titles>
+              <Title LCID="1033" Text="Service" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="Marketing">
+            <Titles>
+              <Title LCID="1033" Text="Marketing" />
+            </Titles>
+          </NavBarArea>
+          <NavBarArea Id="ProcessCenter">
+            <Titles>
+              <Title LCID="1033" Text="Process Sessions" />
+            </Titles>
+          </NavBarArea>
+        </NavBarAreas>
+      </Navigation>
+      <DisplayConditions Order="0" FallbackForm="true">
+        <Everyone />
+      </DisplayConditions>
     </form>
     <IsCustomizable>1</IsCustomizable>
     <CanBeDeleted>1</CanBeDeleted>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_SecondaryMockRecord/Entity.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_SecondaryMockRecord/Entity.xml
@@ -416,6 +416,7 @@
           <Name>owningbusinessunit</Name>
           <LogicalName>owningbusinessunit</LogicalName>
           <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
           <ImeMode>auto</ImeMode>
           <ValidForUpdateApi>0</ValidForUpdateApi>
           <ValidForReadApi>1</ValidForReadApi>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_primarybusinessprocessflow/Entity.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_primarybusinessprocessflow/Entity.xml
@@ -83,7 +83,7 @@
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
           <Format>date</Format>
-          <CanChangeDateTimeBehavior>1</CanChangeDateTimeBehavior>
+          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
           <Behavior>1</Behavior>
           <displaynames>
             <displayname description="Active Stage Started On" languagecode="1033" />
@@ -280,7 +280,7 @@
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
           <Format>date</Format>
-          <CanChangeDateTimeBehavior>1</CanChangeDateTimeBehavior>
+          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
           <Behavior>1</Behavior>
           <displaynames>
             <displayname description="Completed On" languagecode="1033" />
@@ -594,6 +594,7 @@
           <IsFilterable>0</IsFilterable>
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
+          <LookupStyle>single</LookupStyle>
           <LookupTypes />
           <displaynames>
             <displayname description="Organization Id" languagecode="1033" />

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_secondarybusinessprocessflow/Entity.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Entities/sb_secondarybusinessprocessflow/Entity.xml
@@ -83,7 +83,7 @@
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
           <Format>date</Format>
-          <CanChangeDateTimeBehavior>1</CanChangeDateTimeBehavior>
+          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
           <Behavior>1</Behavior>
           <displaynames>
             <displayname description="Active Stage Started On" languagecode="1033" />
@@ -280,7 +280,7 @@
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
           <Format>date</Format>
-          <CanChangeDateTimeBehavior>1</CanChangeDateTimeBehavior>
+          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
           <Behavior>1</Behavior>
           <displaynames>
             <displayname description="Completed On" languagecode="1033" />
@@ -594,6 +594,7 @@
           <IsFilterable>0</IsFilterable>
           <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
+          <LookupStyle>single</LookupStyle>
           <LookupTypes />
           <displaynames>
             <displayname description="Organization Id" languagecode="1033" />

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Account.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Account.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Account</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -43,6 +44,7 @@
     <ReferencedEntityName>Account</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -77,6 +79,7 @@
     <ReferencedEntityName>Account</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/BusinessUnit.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/BusinessUnit.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>BusinessUnit</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>BusinessUnit</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Contact.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Contact.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Contact</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -43,6 +44,7 @@
     <ReferencedEntityName>Contact</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -77,6 +79,7 @@
     <ReferencedEntityName>Contact</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Organization.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Organization.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Organization</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>Organization</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Owner.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Owner.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Owner</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>Owner</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/ProcessStage.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/ProcessStage.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>ProcessStage</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>ProcessStage</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/SystemUser.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/SystemUser.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -47,6 +49,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -66,6 +69,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -85,6 +89,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -104,6 +109,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -123,6 +129,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -142,6 +149,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -161,6 +169,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -180,6 +189,7 @@
     <ReferencedEntityName>SystemUser</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Team.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Team.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Team</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>Team</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/TransactionCurrency.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/TransactionCurrency.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>TransactionCurrency</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>Restrict</CascadeDelete>
+    <CascadeArchive>Restrict</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>TransactionCurrency</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>Restrict</CascadeDelete>
+    <CascadeArchive>Restrict</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Workflow.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/Workflow.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>Workflow</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -28,6 +29,7 @@
     <ReferencedEntityName>Workflow</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>NoCascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/sb_MockRecord.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/sb_MockRecord.xml
@@ -9,6 +9,7 @@
     <ReferencedEntityName>sb_MockRecord</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>Cascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -43,6 +44,7 @@
     <ReferencedEntityName>sb_MockRecord</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>Cascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -77,6 +79,7 @@
     <ReferencedEntityName>sb_MockRecord</ReferencedEntityName>
     <CascadeAssign>Cascade</CascadeAssign>
     <CascadeDelete>Cascade</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>Cascade</CascadeReparent>
     <CascadeShare>Cascade</CascadeShare>
     <CascadeUnshare>Cascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/sb_SecondaryMockRecord.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Relationships/sb_SecondaryMockRecord.xml
@@ -35,6 +35,7 @@
     <ReferencedEntityName>sb_SecondaryMockRecord</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>
@@ -69,6 +70,7 @@
     <ReferencedEntityName>sb_SecondaryMockRecord</ReferencedEntityName>
     <CascadeAssign>NoCascade</CascadeAssign>
     <CascadeDelete>RemoveLink</CascadeDelete>
+    <CascadeArchive>NoCascade</CascadeArchive>
     <CascadeReparent>NoCascade</CascadeReparent>
     <CascadeShare>NoCascade</CascadeShare>
     <CascadeUnshare>NoCascade</CascadeUnshare>

--- a/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Solution.xml
+++ b/bindings/tests/sb_PowerAppsSpecFlowBindings_Mock/src/Other/Solution.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ImportExportXml version="9.1.0.26437" SolutionPackageVersion="9.1" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ImportExportXml version="9.2.22104.192" SolutionPackageVersion="9.2" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SolutionManifest>
     <UniqueName>sb_PowerAppsSpecFlowBindings_Mock</UniqueName>
     <LocalizedNames>
@@ -7,7 +7,7 @@
     </LocalizedNames>
     <Descriptions />
     <Version>1.0.0.2</Version>
-    <Managed>2</Managed>
+    <Managed>1</Managed>
     <Publisher>
       <UniqueName>powerappsspecflowbindings</UniqueName>
       <LocalizedNames>
@@ -87,11 +87,7 @@
       <RootComponent type="29" id="{a35908fe-0fcd-4eb7-826c-405286de4d9d}" behavior="0" />
       <RootComponent type="29" id="{d21a6986-eb11-429c-b4b1-bb747eeb0991}" behavior="0" />
       <RootComponent type="60" id="{50687e45-f839-eb11-a813-000d3a0b97ca}" behavior="0" />
-      <RootComponent type="60" id="{5cdd3da8-0b3a-eb11-a813-000d3a0b97ca}" behavior="0" />
-      <RootComponent type="60" id="{64f94a07-433f-4a64-a290-16238d710ab3}" behavior="0" />
       <RootComponent type="60" id="{6e43bd18-f839-eb11-a813-000d3a0b97ca}" behavior="0" />
-      <RootComponent type="60" id="{974e0b5b-0d50-40fd-b607-61bb0812dda0}" behavior="0" />
-      <RootComponent type="60" id="{e75d54f4-033a-eb11-a813-000d3a0b97ca}" behavior="0" />
       <RootComponent type="61" schemaName="sb_/js/sb_mockrecord.form.js" behavior="0" />
       <RootComponent type="61" schemaName="sb_/js/sb_mockrecord.ribbon.js" behavior="0" />
       <RootComponent type="62" schemaName="sb_MockApp" behavior="0" />
@@ -99,8 +95,8 @@
     </RootComponents>
     <MissingDependencies>
       <MissingDependency>
-        <Required key="0" type="61" schemaName="msdyn_/Images/AppModule_Default_Icon.png" displayName="msdyn_/Images/AppModule_Default_Icon.png" solution="AppModuleWebResources (2.5)" />
-        <Dependent key="1" type="80" schemaName="sb_MockApp" displayName="Mock App" />
+        <Required type="61" schemaName="msdyn_/Images/AppModule_Default_Icon.png" displayName="msdyn_/Images/AppModule_Default_Icon.png" solution="AppModuleWebResources (2.5)" />
+        <Dependent type="80" schemaName="sb_MockApp" displayName="Mock App" />
       </MissingDependency>
     </MissingDependencies>
   </SolutionManifest>


### PR DESCRIPTION
A new entity step binding has been added to assert if the auto-number field contains value as per the input pattern/format those defined by the [Power Platform Docs](https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/create-auto-number-attributes?view=op-9-1#autonumberformat-options).
This resolves the issue #94 

## Purpose
To validate the format of an auto-number field when a record is created

## Approach
Added a new entity step binding to assert the auto-number field value_

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
