### PR TITLE
Fixed cookie setting, added support for MFA 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ users: # mandatory
   - username: SPECFLOW_POWERAPPS_USERNAME_SALESPERSON # mandatory
     password: SPECFLOW_POWERAPPS_PASSWORD_SALESPERSON # optional - populate if this user will be logging in for tests
     alias: a salesperson # mandatory
+    otptoken: SPECFLOW_POWERAPPS_OTPTOKEN_SALESPERSON # optional - populate if this user has MFA enabled
 ```
 
 The URL, driversPath, usernames, passwords, and application user details will be set from environment variable (if found). Otherwise, the value from the config file will be used. The browserOptions node supports anything in the EasyRepro `BrowserOptions` class.

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/BrowserOptionsWithProfileSupport.cs
@@ -22,6 +22,7 @@
         public BrowserOptionsWithProfileSupport()
             : base()
         {
+            this.CookieСontrolsMode = 0;
             this.AdditionalCapabilities = new Dictionary<string, object>();
         }
 

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
@@ -27,5 +27,11 @@
         /// </summary>
         [YamlMember(Alias = "alias")]
         public string Alias { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OTP token of the user.
+        /// </summary>
+        [YamlMember(Alias = "otptoken")]
+        public string OtpToken { get; set; }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
@@ -32,6 +32,6 @@
         /// Gets or sets the OTP token of the user.
         /// </summary>
         [YamlMember(Alias = "otptoken")]
-        public string OtpToken { get; set; }
+        public string OtpToken { get => ConfigHelper.GetEnvironmentVariableIfExists(this.OtpToken); set => this.OtpToken = value; }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/UserConfiguration.cs
@@ -9,6 +9,7 @@
     {
         private string username;
         private string password;
+        private string otptoken;
 
         /// <summary>
         /// Gets or sets the username of the user.
@@ -32,6 +33,6 @@
         /// Gets or sets the OTP token of the user.
         /// </summary>
         [YamlMember(Alias = "otptoken")]
-        public string OtpToken { get => ConfigHelper.GetEnvironmentVariableIfExists(this.OtpToken); set => this.OtpToken = value; }
+        public string OtpToken { get => ConfigHelper.GetEnvironmentVariableIfExists(this.otptoken); set => this.otptoken = value; }
     }
 }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Steps/LoginSteps.cs
@@ -31,7 +31,14 @@
 
             var url = TestConfig.GetTestUrl();
 
-            XrmApp.OnlineLogin.Login(url, user.Username.ToSecureString(), user.Password.ToSecureString());
+            if (!string.IsNullOrEmpty(user.OtpToken))
+            {
+                XrmApp.OnlineLogin.Login(url, user.Username.ToSecureString(), user.Password.ToSecureString(), user.OtpToken.ToSecureString());
+            }
+            else
+            {
+                XrmApp.OnlineLogin.Login(url, user.Username.ToSecureString(), user.Password.ToSecureString());
+            }
 
             if (!url.Query.Contains("appid"))
             {


### PR DESCRIPTION
## Purpose
 - Changed the cookie policy in browser settings to allow 3rd party cookies. This blocked the log in and prompted the user to log in again right after logging in. [This page](https://learn.microsoft.com/en-us/answers/questions/1071292/sign-in-to-continue-some-components-of-this-app-re)  explains the error we ran into

 - Added optional otp token property to user info. Now, a step utilizing the XrmApp.OnlineLogin.Login method can be created to work with MFA. I also modified the login step to use this method

## Approach
This approach solves MFA being enabled on the test user and also fixes repeated login popup

## TODOs
- [ ] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
