### PR TITLE
fix: screenshot failure prevents driver cleanup

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -52,21 +52,31 @@
         [AfterScenario(Order = 0)]
         public void ScreenshotFailedScenario()
         {
-            if (this.scenarioContext.ScenarioExecutionStatus == ScenarioExecutionStatus.TestError)
+            if (this.scenarioContext.ScenarioExecutionStatus != ScenarioExecutionStatus.TestError)
             {
-                var rootFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                var screenshotsFolder = Path.Combine(rootFolder, "screenshots");
-                Console.WriteLine(screenshotsFolder);
+                return;
+            }
 
-                if (!Directory.Exists(screenshotsFolder))
-                {
-                    Directory.CreateDirectory(screenshotsFolder);
-                }
+            var rootFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var screenshotsFolder = Path.Combine(rootFolder, "screenshots");
 
-                var fileName = string.Concat(this.scenarioContext.ScenarioInfo.Title.Split(Path.GetInvalidFileNameChars()));
+            if (!Directory.Exists(screenshotsFolder))
+            {
+                Directory.CreateDirectory(screenshotsFolder);
+            }
+
+            var fileName = string.Concat(this.scenarioContext.ScenarioInfo.Title.Split(Path.GetInvalidFileNameChars()));
+
+            try
+            {
                 Client.Browser.TakeWindowScreenShot(
                     Path.Combine(screenshotsFolder, $"{fileName}.jpg"),
                     ScreenshotImageFormat.Jpeg);
+            }
+            catch (WebDriverException ex)
+            {
+                // Don't throw an unhandled exception if the screenshot can't be captured as this will prevent the WebDriver instance from being cleaned up.
+                Console.WriteLine($"Failed to capture screenshot: {ex.Message}.");
             }
         }
     }


### PR DESCRIPTION
## Purpose
As explained in the SpecFlow [Hooks](https://docs.specflow.org/projects/specflow/en/latest/Bindings/Hooks.html?) docs, an unhandled exception thrown in a hook will prevent later hooks from executing. We capture screenshots in an `AfterScenario` hook before we clean-up the `WebDriver` in a subsequent `AfterScenario` hook. This means if the screenshot fails to capture for any reason (e.g. the Selenium Grid session has timed out), the clean-up hook will not happen and all subsequent tests will fail.

## Approach
Wraps the screenshot capture in a try/catch.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
