### PR TITLE
fix: GetUser returns 'current user' from other tests

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -19,6 +19,7 @@
 
         private const string GetUserException = "Unable to retrieve user configuration. Please ensure a user with the given alias exists in the config.";
 
+        [ThreadStatic]
         private static readonly Dictionary<string, UserConfiguration> CurrentUsers = new Dictionary<string, UserConfiguration>();
 
         private readonly object userEnumeratorsLock = new object();

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Configuration/TestConfiguration.cs
@@ -20,7 +20,7 @@
         private const string GetUserException = "Unable to retrieve user configuration. Please ensure a user with the given alias exists in the config.";
 
         [ThreadStatic]
-        private static readonly Dictionary<string, UserConfiguration> CurrentUsers = new Dictionary<string, UserConfiguration>();
+        private static Dictionary<string, UserConfiguration> currentUsers;
 
         private readonly object userEnumeratorsLock = new object();
         private Dictionary<string, IEnumerator<UserConfiguration>> userEnumerators;
@@ -76,6 +76,19 @@
         [YamlMember(Alias = "applicationUser")]
         public ClientCredentials ApplicationUser { get; set; }
 
+        private Dictionary<string, UserConfiguration> CurrentUsers
+        {
+            get
+            {
+                if (currentUsers == null)
+                {
+                    currentUsers = new Dictionary<string, UserConfiguration>();
+                }
+
+                return currentUsers;
+            }
+        }
+
         [YamlIgnore]
         private Dictionary<string, IEnumerator<UserConfiguration>> UserEnumerators
         {
@@ -115,9 +128,9 @@
         /// <returns>The user configuration.</returns>
         public UserConfiguration GetUser(string userAlias, bool useCurrentUser = true)
         {
-            if (useCurrentUser && CurrentUsers.ContainsKey(userAlias))
+            if (useCurrentUser && this.CurrentUsers.ContainsKey(userAlias))
             {
-                return CurrentUsers[userAlias];
+                return this.CurrentUsers[userAlias];
             }
 
             try
@@ -132,13 +145,13 @@
                         aliasEnumerator.MoveNext();
                     }
 
-                    if (CurrentUsers.ContainsKey(userAlias))
+                    if (this.CurrentUsers.ContainsKey(userAlias))
                     {
-                        CurrentUsers[userAlias] = aliasEnumerator.Current;
+                        this.CurrentUsers[userAlias] = aliasEnumerator.Current;
                     }
                     else
                     {
-                        CurrentUsers.Add(userAlias, aliasEnumerator.Current);
+                        this.CurrentUsers.Add(userAlias, aliasEnumerator.Current);
                     }
                 }
             }
@@ -147,7 +160,7 @@
                 throw new ConfigurationErrorsException($"{GetUserException} User: {userAlias}", ex);
             }
 
-            return CurrentUsers[userAlias];
+            return this.CurrentUsers[userAlias];
         }
 
         /// <summary>
@@ -155,7 +168,7 @@
         /// </summary>
         internal void Flush()
         {
-            CurrentUsers.Clear();
+            this.CurrentUsers.Clear();
         }
 
         private IEnumerator<UserConfiguration> GetUserEnumerator(string alias)


### PR DESCRIPTION
## Purpose
The default behaviour of `TestConfig.GetUser` is to get the `current user` of an alias. If the test has previously called `GetUser` with a given alias, the same user will be returned as was returned previously. This works fine when running tests sequentially or in separate AppDomains, but when multiple tests execute concurrently in the same AppDomain, the wrong current user is returned.

## Approach
Updates the `CurrentUsers` field to be `ThreadStatic`.

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
