### PR TITLE
fix: screenshots captured on failure even if app not loaded

### DIFF
--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/Hooks/AfterScenarioHooks.cs
@@ -24,35 +24,12 @@
         }
 
         /// <summary>
-        /// Deletes the test data created during the test and disposes of the browser.
-        /// </summary>
-        [AfterScenario(Order = 1)]
-        public static void TestCleanup()
-        {
-            try
-            {
-                if (TestConfig.DeleteTestData)
-                {
-                    TestDriver.DeleteTestData();
-                }
-            }
-            catch (WebDriverException)
-            {
-                // Ignore - tests might have failed before driver was initialised.
-            }
-            finally
-            {
-                Quit();
-            }
-        }
-
-        /// <summary>
         /// Takes a screenshot of the browser when a test fails.
         /// </summary>
         [AfterScenario(Order = 0)]
         public void ScreenshotFailedScenario()
         {
-            if (this.scenarioContext.ScenarioExecutionStatus != ScenarioExecutionStatus.TestError)
+            if (this.scenarioContext.ScenarioExecutionStatus != ScenarioExecutionStatus.TestError || !WebClientInitialised)
             {
                 return;
             }
@@ -77,6 +54,29 @@
             {
                 // Don't throw an unhandled exception if the screenshot can't be captured as this will prevent the WebDriver instance from being cleaned up.
                 Console.WriteLine($"Failed to capture screenshot: {ex.Message}.");
+            }
+        }
+
+        /// <summary>
+        /// Deletes the test data created during the test and disposes of the browser.
+        /// </summary>
+        [AfterScenario(Order = 1)]
+        public void TestCleanup()
+        {
+            try
+            {
+                if (TestConfig.DeleteTestData)
+                {
+                    TestDriver.DeleteTestData();
+                }
+            }
+            catch (WebDriverException)
+            {
+                // Ignore - tests might have failed before driver was initialised.
+            }
+            finally
+            {
+                Quit();
             }
         }
     }

--- a/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
+++ b/bindings/src/Capgemini.PowerApps.SpecFlowBindings/PowerAppsStepDefiner.cs
@@ -44,6 +44,11 @@
         private static object userProfilesDirectoriesLock = new object();
 
         /// <summary>
+        /// Gets a value indicating whether or not a <see cref="WebClient"/> instance has been initialised for the current test thread.
+        /// </summary>
+        internal static bool WebClientInitialised => client != null;
+
+        /// <summary>
         /// Gets access token used to authenticate as the application user configured for testing.
         /// </summary>
         protected static string AccessToken


### PR DESCRIPTION
This is causing some performance issues as it results in a Web Driver instance being created unnecessarily - a problem especially when using Selenium Grid.